### PR TITLE
Add Makefile with SFML setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+CXX = g++
+CXXFLAGS = -std=c++17 -Iinclude -Isrc
+
+SRCS = $(filter-out src/quest.cpp,$(wildcard src/*.cpp))
+OBJS = $(SRCS:.cpp=.o)
+TARGET = galactic_miner
+
+SFML_LIBS = $(shell pkg-config --libs sfml-graphics sfml-window sfml-system sfml-audio 2>/dev/null)
+SFML_CFLAGS = $(shell pkg-config --cflags sfml-graphics sfml-window sfml-system sfml-audio 2>/dev/null)
+
+all: check_sfml $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CXX) $(CXXFLAGS) $(OBJS) -o $(TARGET) $(SFML_LIBS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) $(SFML_CFLAGS) -c $< -o $@
+
+check_sfml:
+	@pkg-config --exists sfml-graphics || (\
+	echo "SFML not found, installing..." && \
+	sudo apt-get update && sudo apt-get install -y libsfml-dev)
+
+clean:
+	rm -f $(OBJS)
+
+fclean: clean
+	rm -f $(TARGET)
+
+re: fclean all
+
+.PHONY: all clean fclean re check_sfml

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,20 @@
+#include <SFML/Graphics.hpp>
+#include "planet.h"
+#include "game_data.h"
+#include <iostream>
+
+int main() {
+    sf::RenderWindow window(sf::VideoMode(800, 600), "Galactic Planet Miner");
+
+    while (window.isOpen()) {
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed)
+                window.close();
+        }
+
+        window.clear(sf::Color::Black);
+        window.display();
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple Makefile that compiles sources and installs SFML if needed
- add minimal `main.cpp` with an SFML window example

## Testing
- `pkg-config --exists sfml-graphics`
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6862cb859e4883319ab13e76df277f67