### PR TITLE
Add basic resource production for planets

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -29,6 +29,28 @@ Game::~Game()
     return ;
 }
 
+void Game::produce(double seconds)
+{
+    int planet_ids[] = {
+        PLANET_TERRA,
+        PLANET_MARS,
+        PLANET_ZALTHOR,
+        PLANET_VULCAN,
+        PLANET_NOCTARIS_PRIME
+    };
+    size_t count = sizeof(planet_ids) / sizeof(planet_ids[0]);
+    for (size_t i = 0; i < count; ++i)
+    {
+        int planet_id = planet_ids[i];
+        ft_sharedptr<ft_planet> planet = this->get_planet(planet_id);
+        if (!planet)
+            continue;
+        ft_vector<Pair<int, int> > produced = planet->produce(seconds);
+        for (size_t j = 0; j < produced.size(); ++j)
+            this->send_state(planet_id, produced[j].key);
+    }
+}
+
 ft_sharedptr<ft_planet> Game::get_planet(int id)
 {
     Pair<int, ft_sharedptr<ft_planet> > *entry = this->_planets.find(id);

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -25,6 +25,8 @@ public:
     Game(const ft_string &host, const ft_string &path);
     ~Game();
 
+    void produce(double seconds);
+
     int add_ore(int planet_id, int ore_id, int amount);
     int sub_ore(int planet_id, int ore_id, int amount);
     int get_ore(int planet_id, int ore_id) const;

--- a/src/planets.cpp
+++ b/src/planets.cpp
@@ -97,3 +97,23 @@ const ft_vector<Pair<int, double> > &ft_planet::get_resources() const noexcept
     return this->_rates;
 }
 
+ft_vector<Pair<int, int> > ft_planet::produce(double seconds) noexcept
+{
+    ft_vector<Pair<int, int> > produced;
+    for (size_t i = 0; i < this->_rates.size(); ++i)
+    {
+        int ore_id = this->_rates[i].key;
+        double rate = this->_rates[i].value;
+        int amount = static_cast<int>(rate * seconds);
+        if (amount > 0)
+        {
+            this->add_resource(ore_id, amount);
+            Pair<int, int> entry;
+            entry.key = ore_id;
+            entry.value = amount;
+            produced.push_back(entry);
+        }
+    }
+    return produced;
+}
+

--- a/src/planets.hpp
+++ b/src/planets.hpp
@@ -61,6 +61,7 @@ public:
     void set_resource(int ore_id, int amount) noexcept;
     double get_rate(int ore_id) const noexcept;
     const ft_vector<Pair<int, double> > &get_resources() const noexcept;
+    ft_vector<Pair<int, int> > produce(double seconds) noexcept;
 };
 
 class ft_planet_terra : public ft_planet

--- a/tests/game_test.cpp
+++ b/tests/game_test.cpp
@@ -45,6 +45,9 @@ int main()
     double mithril_rate = game.get_rate(PLANET_MARS, ORE_MITHRIL);
     FT_ASSERT(mithril_rate > 0.049 && mithril_rate < 0.051);
 
+    game.produce(10.0);
+    FT_ASSERT_EQ(12, game.get_ore(PLANET_TERRA, ORE_IRON));
+
     game.create_fleet(1);
     int ship_a = game.create_ship(1, SHIP_SHIELD);
     int ship_b = game.create_ship(1, SHIP_SHIELD);


### PR DESCRIPTION
## Summary
- add `ft_planet::produce` to grow ores based on per-second rates
- expose `Game::produce` to advance time and sync backend state
- cover resource production with test case

## Testing
- `make test` *(fails: No rule to make target 'Full_Libft.a')*

------
https://chatgpt.com/codex/tasks/task_e_68c8210e0fc0833198fcdd77e1ea0d37