### PR TITLE
Add ore transfer game logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Basic components are also enumerated for future crafting systems:
 - `ITEM_MITHRIL_BAR` (1003)
 - `ITEM_ENGINE_PART` (1004)
 
-Use the helper methods in `Game` to add, subtract, set, and query ore amounts
+Use the helper methods in `Game` to add, subtract, set, transfer, and query ore amounts
 by planet ID (`PLANET_TERRA` etc.) and ore ID, and to read mining rates with
 `get_rate` or list all resources for a planet with `get_planet_resources`.
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -136,6 +136,24 @@ void Game::set_ore(int planet_id, int ore_id, int amount)
     this->send_state(planet_id, ore_id);
 }
 
+int Game::transfer_ore(int from_planet_id, int to_planet_id, int ore_id, int amount)
+{
+    ft_sharedptr<ft_planet> from = this->get_planet(from_planet_id);
+    ft_sharedptr<ft_planet> to = this->get_planet(to_planet_id);
+    if (!from || !to)
+        return 0;
+    int available = from->get_resource(ore_id);
+    if (amount > available)
+        amount = available;
+    if (amount <= 0)
+        return 0;
+    from->sub_resource(ore_id, amount);
+    to->add_resource(ore_id, amount);
+    this->send_state(from_planet_id, ore_id);
+    this->send_state(to_planet_id, ore_id);
+    return amount;
+}
+
 double Game::get_rate(int planet_id, int ore_id) const
 {
     ft_sharedptr<const ft_planet> planet = this->get_planet(planet_id);

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -31,6 +31,7 @@ public:
     int sub_ore(int planet_id, int ore_id, int amount);
     int get_ore(int planet_id, int ore_id) const;
     void set_ore(int planet_id, int ore_id, int amount);
+    int transfer_ore(int from_planet_id, int to_planet_id, int ore_id, int amount);
     double get_rate(int planet_id, int ore_id) const;
     const ft_vector<Pair<int, double> > &get_planet_resources(int planet_id) const;
 

--- a/tests/game_test.cpp
+++ b/tests/game_test.cpp
@@ -48,6 +48,13 @@ int main()
     game.produce(10.0);
     FT_ASSERT_EQ(12, game.get_ore(PLANET_TERRA, ORE_IRON));
 
+    game.set_ore(PLANET_TERRA, ORE_COPPER, 10);
+    game.set_ore(PLANET_MARS, ORE_COPPER, 0);
+    int moved = game.transfer_ore(PLANET_TERRA, PLANET_MARS, ORE_COPPER, 4);
+    FT_ASSERT_EQ(4, moved);
+    FT_ASSERT_EQ(6, game.get_ore(PLANET_TERRA, ORE_COPPER));
+    FT_ASSERT_EQ(4, game.get_ore(PLANET_MARS, ORE_COPPER));
+
     game.create_fleet(1);
     int ship_a = game.create_ship(1, SHIP_SHIELD);
     int ship_b = game.create_ship(1, SHIP_SHIELD);


### PR DESCRIPTION
## Summary
- enable moving ore between planets with a new `transfer_ore` helper
- document the ore transfer API
- test ore transfers in the existing game test suite

## Testing
- `make`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_68c826318010833196a715d3beb69103