### PR TITLE
Add timed fleet travel and ship transfer options with planetary disbanding

### DIFF
--- a/src/fleets.cpp
+++ b/src/fleets.cpp
@@ -2,7 +2,12 @@
 
 int ft_fleet::_next_ship_id = 1;
 
-ft_fleet::ft_fleet(int id) noexcept : _id(id)
+ft_fleet::ft_fleet() noexcept : _id(0), _travel_time(0)
+{
+    return ;
+}
+
+ft_fleet::ft_fleet(int id) noexcept : _id(id), _travel_time(0)
 {
     return ;
 }
@@ -39,6 +44,27 @@ int ft_fleet::create_ship(int ship_type) noexcept
 void ft_fleet::remove_ship(int ship_uid) noexcept
 {
     this->_ships.remove(ship_uid);
+}
+
+bool ft_fleet::move_ship_to(ft_fleet &target, int ship_uid) noexcept
+{
+    ft_ship *ship = this->find_ship(ship_uid);
+    if (ship == ft_nullptr)
+        return false;
+    target._ships.insert(ship_uid, *ship);
+    this->_ships.remove(ship_uid);
+    return true;
+}
+
+void ft_fleet::move_ships_to(ft_fleet &target) noexcept
+{
+    while (this->_ships.size() > 0)
+    {
+        Pair<int, ft_ship> *entry = this->_ships.end();
+        entry -= 1;
+        target._ships.insert(entry->key, entry->value);
+        this->_ships.remove(entry->key);
+    }
 }
 
 void ft_fleet::set_ship_armor(int ship_uid, int value) noexcept
@@ -155,14 +181,16 @@ void ft_fleet::set_location_planet(int planet_id) noexcept
     this->_loc.from = planet_id;
     this->_loc.to = planet_id;
     this->_loc.misc = 0;
+    this->_travel_time = 0;
 }
 
-void ft_fleet::set_location_travel(int from, int to) noexcept
+void ft_fleet::set_location_travel(int from, int to, double time) noexcept
 {
     this->_loc.type = LOCATION_TRAVEL;
     this->_loc.from = from;
     this->_loc.to = to;
     this->_loc.misc = 0;
+    this->_travel_time = time;
 }
 
 void ft_fleet::set_location_misc(int misc_id) noexcept
@@ -171,10 +199,29 @@ void ft_fleet::set_location_misc(int misc_id) noexcept
     this->_loc.from = 0;
     this->_loc.to = 0;
     this->_loc.misc = misc_id;
+    this->_travel_time = 0;
 }
 
 ft_location ft_fleet::get_location() const noexcept
 {
     return this->_loc;
+}
+
+double ft_fleet::get_travel_time() const noexcept
+{
+    return this->_travel_time;
+}
+
+void ft_fleet::tick(double seconds) noexcept
+{
+    if (this->_loc.type == LOCATION_TRAVEL)
+    {
+        if (this->_travel_time > seconds)
+            this->_travel_time -= seconds;
+        else
+        {
+            this->set_location_planet(this->_loc.to);
+        }
+    }
 }
 

--- a/src/fleets.hpp
+++ b/src/fleets.hpp
@@ -55,18 +55,22 @@ private:
     int                    _id;
     ft_map<int, ft_ship>   _ships;
     ft_location            _loc;
+    double                 _travel_time;
     static int             _next_ship_id;
 
     ft_ship *find_ship(int ship_uid) noexcept;
     const ft_ship *find_ship(int ship_uid) const noexcept;
 
 public:
+    ft_fleet() noexcept;
     explicit ft_fleet(int id) noexcept;
 
     int get_id() const noexcept;
 
     int create_ship(int ship_type) noexcept;
     void remove_ship(int ship_uid) noexcept;
+    bool move_ship_to(ft_fleet &target, int ship_uid) noexcept;
+    void move_ships_to(ft_fleet &target) noexcept;
 
     void set_ship_armor(int ship_uid, int value) noexcept;
     int get_ship_armor(int ship_uid) const noexcept;
@@ -84,9 +88,11 @@ public:
     int sub_ship_shield(int ship_uid, int amount) noexcept;
 
     void set_location_planet(int planet_id) noexcept;
-    void set_location_travel(int from, int to) noexcept;
+    void set_location_travel(int from, int to, double time) noexcept;
     void set_location_misc(int misc_id) noexcept;
     ft_location get_location() const noexcept;
+    double get_travel_time() const noexcept;
+    void tick(double seconds) noexcept;
 };
 
 #endif

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -13,12 +13,15 @@ private:
     ft_game_state                                 _state;
     ft_map<int, ft_sharedptr<ft_planet> >         _planets;
     ft_map<int, ft_sharedptr<ft_fleet> >          _fleets;
+    ft_map<int, ft_sharedptr<ft_fleet> >          _planet_fleets;
     BackendClient                                _backend;
 
     ft_sharedptr<ft_planet> get_planet(int id);
     ft_sharedptr<const ft_planet> get_planet(int id) const;
     ft_sharedptr<ft_fleet> get_fleet(int id);
     ft_sharedptr<const ft_fleet> get_fleet(int id) const;
+    ft_sharedptr<ft_fleet> get_planet_fleet(int id);
+    ft_sharedptr<const ft_fleet> get_planet_fleet(int id) const;
     void send_state(int planet_id, int ore_id);
 
 public:
@@ -37,9 +40,10 @@ public:
     const ft_vector<Pair<int, double> > &get_planet_resources(int planet_id) const;
 
     void create_fleet(int fleet_id);
-    void remove_fleet(int fleet_id);
+    void remove_fleet(int fleet_id, int target_fleet_id = -1, int target_planet_id = -1);
     int create_ship(int fleet_id, int ship_type);
     void remove_ship(int fleet_id, int ship_uid);
+    bool transfer_ship(int from_fleet_id, int to_fleet_id, int ship_uid);
 
     void set_ship_armor(int fleet_id, int ship_uid, int value);
     int get_ship_armor(int fleet_id, int ship_uid) const;
@@ -57,9 +61,12 @@ public:
     int sub_ship_shield(int fleet_id, int ship_uid, int amount);
 
     void set_fleet_location_planet(int fleet_id, int planet_id);
-    void set_fleet_location_travel(int fleet_id, int from, int to);
+    void set_fleet_location_travel(int fleet_id, int from, int to, double time);
     void set_fleet_location_misc(int fleet_id, int misc_id);
     ft_location get_fleet_location(int fleet_id) const;
+    double get_fleet_travel_time(int fleet_id) const;
+    int get_planet_fleet_ship_hp(int planet_id, int ship_uid) const;
+    ft_location get_planet_fleet_location(int planet_id) const;
 };
 
 #endif

--- a/tests/game_test.cpp
+++ b/tests/game_test.cpp
@@ -90,11 +90,13 @@ int main()
     int ship_c = game.create_ship(2, SHIP_SHIELD);
     FT_ASSERT(ship_c != ship_a);
     FT_ASSERT(ship_c != ship_b);
-    game.set_fleet_location_travel(2, PLANET_MARS, PLANET_VULCAN);
+    game.set_fleet_location_travel(2, PLANET_MARS, PLANET_VULCAN, 5.0);
     ft_location loc2 = game.get_fleet_location(2);
     FT_ASSERT_EQ(LOCATION_TRAVEL, loc2.type);
     FT_ASSERT_EQ(PLANET_MARS, loc2.from);
     FT_ASSERT_EQ(PLANET_VULCAN, loc2.to);
+    double travel_time = game.get_fleet_travel_time(2);
+    FT_ASSERT(travel_time > 4.9 && travel_time < 5.1);
 
     game.set_fleet_location_misc(1, MISC_OUTPOST_NEBULA_X);
     ft_location loc3 = game.get_fleet_location(1);
@@ -105,8 +107,18 @@ int main()
     FT_ASSERT_EQ(0, game.get_ship_hp(1, ship_b));
     FT_ASSERT_EQ(0, game.add_ship_hp(1, ship_b, 10));
 
+    game.transfer_ship(1, 2, ship_a);
+    FT_ASSERT_EQ(0, game.get_ship_hp(1, ship_a));
+    FT_ASSERT_EQ(90, game.get_ship_hp(2, ship_a));
+
     game.set_ore(PLANET_TERRA, ORE_COPPER, 0);
-    game.tick(4.0);
+    game.tick(2.0);
+    FT_ASSERT_EQ(1, game.get_ore(PLANET_TERRA, ORE_COPPER));
+    ft_location loc2a = game.get_fleet_location(2);
+    FT_ASSERT_EQ(LOCATION_TRAVEL, loc2a.type);
+    travel_time = game.get_fleet_travel_time(2);
+    FT_ASSERT(travel_time > 2.9 && travel_time < 3.1);
+    game.tick(3.0);
     FT_ASSERT_EQ(2, game.get_ore(PLANET_TERRA, ORE_COPPER));
     ft_location loc4 = game.get_fleet_location(2);
     FT_ASSERT_EQ(LOCATION_PLANET, loc4.type);
@@ -115,10 +127,32 @@ int main()
     game.create_fleet(3);
     int ship_d = game.create_ship(3, SHIP_SHIELD);
     FT_ASSERT(ship_d != 0);
-    game.remove_fleet(3);
+    game.set_ship_hp(3, ship_d, 42);
+    game.remove_fleet(3, 2);
+    FT_ASSERT_EQ(42, game.get_ship_hp(2, ship_d));
+    FT_ASSERT_EQ(0, game.get_ship_hp(3, ship_d));
     FT_ASSERT_EQ(0, game.create_ship(3, SHIP_SHIELD));
     ft_location loc5 = game.get_fleet_location(3);
     FT_ASSERT_EQ(PLANET_TERRA, loc5.from);
+
+    game.create_fleet(4);
+    int ship_e = game.create_ship(4, SHIP_SHIELD);
+    FT_ASSERT(ship_e != 0);
+    game.set_ship_hp(4, ship_e, 37);
+    game.remove_fleet(4, -1, PLANET_MARS);
+    FT_ASSERT_EQ(0, game.get_ship_hp(4, ship_e));
+    FT_ASSERT_EQ(37, game.get_planet_fleet_ship_hp(PLANET_MARS, ship_e));
+    ft_location mars_garrison = game.get_planet_fleet_location(PLANET_MARS);
+    FT_ASSERT_EQ(LOCATION_PLANET, mars_garrison.type);
+    FT_ASSERT_EQ(PLANET_MARS, mars_garrison.from);
+
+    game.create_fleet(5);
+    int ship_f = game.create_ship(5, SHIP_SHIELD);
+    FT_ASSERT(ship_f != 0);
+    game.set_ship_hp(5, ship_f, 18);
+    game.remove_fleet(5, -1, PLANET_MARS);
+    FT_ASSERT_EQ(37, game.get_planet_fleet_ship_hp(PLANET_MARS, ship_e));
+    FT_ASSERT_EQ(18, game.get_planet_fleet_ship_hp(PLANET_MARS, ship_f));
 
     server_thread.join();
     return 0;


### PR DESCRIPTION
## Summary
- add travel-time tracking to fleets and advance them via `Game::tick`
- allow relocating ships between fleets with new `transfer_ship` and move disbanded fleets into planetary garrisons
- test fleet travel timing alongside moving ships on deletion, including planetary garrison coverage

## Testing
- `make test` *(fails: No rule to make target 'Full_Libft.a')*
- `./test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c82ee359a48331a77b0a78bc4b5660