### PR TITLE
Add startup script to sync libft submodule

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ ! -d "libft/.git" ]; then
+    git submodule update --init --recursive libft
+else
+    git submodule update --recursive --remote libft
+fi
+
+make "$@"


### PR DESCRIPTION
## Summary
- add a startup script that ensures the libft submodule is initialized or updated before invoking the build
- fail fast on errors and forward to `make` so existing build commands continue to work

## Testing
- bash -n scripts/start.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9126ba62483318ac65f0ad8149def