### PR TITLE
Add building management system and crafting flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ SRC_COMMON  = \
     $(SRC_DIR)/backend_client.cpp \
     $(SRC_DIR)/planets.cpp \
     $(SRC_DIR)/fleets.cpp \
+    $(SRC_DIR)/buildings.cpp \
+    $(SRC_DIR)/combat.cpp \
+    $(SRC_DIR)/quests.cpp \
+    $(SRC_DIR)/research.cpp \
     $(SRC_DIR)/game.cpp
 SRC_MAIN    = $(SRC_DIR)/main.cpp
 SRC         = $(SRC_COMMON) $(SRC_MAIN)

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -1,0 +1,700 @@
+#include "buildings.hpp"
+#include "game.hpp"
+#include "../libft/Libft/libft.hpp"
+
+ft_planet_build_state::ft_planet_build_state()
+    : planet_id(0), width(0), height(0), base_logistic(0), used_plots(0),
+      logistic_capacity(0), logistic_usage(0), base_energy_generation(0.0),
+      energy_generation(0.0), energy_consumption(0.0), support_energy(0.0),
+      mine_multiplier(1.0), next_instance_id(1), grid(), instances()
+{
+}
+
+BuildingManager::BuildingManager()
+{
+    ft_sharedptr<ft_building_definition> mine(new ft_building_definition());
+    mine->id = BUILDING_MINE_CORE;
+    mine->name = ft_string("Mine Core");
+    mine->width = 1;
+    mine->height = 1;
+    mine->logistic_cost = 0;
+    mine->logistic_gain = 0;
+    mine->energy_cost = 0.0;
+    mine->energy_gain = 0.0;
+    mine->cycle_time = 0.0;
+    mine->inputs.clear();
+    mine->outputs.clear();
+    mine->build_costs.clear();
+    mine->mine_bonus = 0.0;
+    mine->unique = true;
+    mine->occupies_grid = true;
+    mine->removable = false;
+    this->register_definition(mine);
+
+    ft_sharedptr<ft_building_definition> smelter(new ft_building_definition());
+    smelter->id = BUILDING_SMELTER;
+    smelter->name = ft_string("Smelting Facility");
+    smelter->width = 2;
+    smelter->height = 2;
+    smelter->logistic_cost = 1;
+    smelter->logistic_gain = 0;
+    smelter->energy_cost = 2.0;
+    smelter->energy_gain = 0.0;
+    smelter->cycle_time = 5.0;
+    smelter->inputs.clear();
+    Pair<int, int> recipe;
+    recipe.key = ORE_IRON;
+    recipe.value = 3;
+    smelter->inputs.push_back(recipe);
+    smelter->outputs.clear();
+    recipe.key = ITEM_IRON_BAR;
+    recipe.value = 2;
+    smelter->outputs.push_back(recipe);
+    smelter->build_costs.clear();
+    recipe.key = ORE_IRON;
+    recipe.value = 12;
+    smelter->build_costs.push_back(recipe);
+    recipe.key = ORE_COPPER;
+    recipe.value = 8;
+    smelter->build_costs.push_back(recipe);
+    smelter->mine_bonus = 0.0;
+    smelter->unique = false;
+    smelter->occupies_grid = true;
+    smelter->removable = true;
+    this->register_definition(smelter);
+
+    ft_sharedptr<ft_building_definition> processor(new ft_building_definition());
+    processor->id = BUILDING_PROCESSOR;
+    processor->name = ft_string("Processing Unit");
+    processor->width = 2;
+    processor->height = 2;
+    processor->logistic_cost = 1;
+    processor->logistic_gain = 0;
+    processor->energy_cost = 2.5;
+    processor->energy_gain = 0.0;
+    processor->cycle_time = 6.0;
+    processor->inputs.clear();
+    recipe.key = ORE_COPPER;
+    recipe.value = 3;
+    processor->inputs.push_back(recipe);
+    processor->outputs.clear();
+    recipe.key = ITEM_COPPER_BAR;
+    recipe.value = 2;
+    processor->outputs.push_back(recipe);
+    processor->build_costs.clear();
+    recipe.key = ORE_COPPER;
+    recipe.value = 10;
+    processor->build_costs.push_back(recipe);
+    recipe.key = ORE_COAL;
+    recipe.value = 6;
+    processor->build_costs.push_back(recipe);
+    processor->mine_bonus = 0.0;
+    processor->unique = false;
+    processor->occupies_grid = true;
+    processor->removable = true;
+    this->register_definition(processor);
+
+    ft_sharedptr<ft_building_definition> crafting(new ft_building_definition());
+    crafting->id = BUILDING_CRAFTING_BAY;
+    crafting->name = ft_string("Crafting Bay");
+    crafting->width = 3;
+    crafting->height = 2;
+    crafting->logistic_cost = 2;
+    crafting->logistic_gain = 0;
+    crafting->energy_cost = 4.0;
+    crafting->energy_gain = 0.0;
+    crafting->cycle_time = 8.0;
+    crafting->inputs.clear();
+    recipe.key = ITEM_IRON_BAR;
+    recipe.value = 2;
+    crafting->inputs.push_back(recipe);
+    recipe.key = ITEM_COPPER_BAR;
+    recipe.value = 1;
+    crafting->inputs.push_back(recipe);
+    crafting->outputs.clear();
+    recipe.key = ITEM_ENGINE_PART;
+    recipe.value = 1;
+    crafting->outputs.push_back(recipe);
+    crafting->build_costs.clear();
+    recipe.key = ORE_IRON;
+    recipe.value = 8;
+    crafting->build_costs.push_back(recipe);
+    recipe.key = ORE_COPPER;
+    recipe.value = 10;
+    crafting->build_costs.push_back(recipe);
+    recipe.key = ORE_COAL;
+    recipe.value = 6;
+    crafting->build_costs.push_back(recipe);
+    crafting->mine_bonus = 0.0;
+    crafting->unique = false;
+    crafting->occupies_grid = true;
+    crafting->removable = true;
+    this->register_definition(crafting);
+
+    ft_sharedptr<ft_building_definition> conveyor(new ft_building_definition());
+    conveyor->id = BUILDING_CONVEYOR;
+    conveyor->name = ft_string("Conveyor Belt");
+    conveyor->width = 1;
+    conveyor->height = 1;
+    conveyor->logistic_cost = 0;
+    conveyor->logistic_gain = 1;
+    conveyor->energy_cost = 0.0;
+    conveyor->energy_gain = 0.0;
+    conveyor->cycle_time = 0.0;
+    conveyor->inputs.clear();
+    conveyor->outputs.clear();
+    conveyor->build_costs.clear();
+    recipe.key = ORE_IRON;
+    recipe.value = 4;
+    conveyor->build_costs.push_back(recipe);
+    conveyor->mine_bonus = 0.0;
+    conveyor->unique = false;
+    conveyor->occupies_grid = true;
+    conveyor->removable = true;
+    this->register_definition(conveyor);
+
+    ft_sharedptr<ft_building_definition> transfer(new ft_building_definition());
+    transfer->id = BUILDING_TRANSFER_NODE;
+    transfer->name = ft_string("Resource Transfer Node");
+    transfer->width = 1;
+    transfer->height = 1;
+    transfer->logistic_cost = 0;
+    transfer->logistic_gain = 2;
+    transfer->energy_cost = 0.0;
+    transfer->energy_gain = 0.0;
+    transfer->cycle_time = 0.0;
+    transfer->inputs.clear();
+    transfer->outputs.clear();
+    transfer->build_costs.clear();
+    recipe.key = ORE_IRON;
+    recipe.value = 6;
+    transfer->build_costs.push_back(recipe);
+    recipe.key = ORE_COPPER;
+    recipe.value = 4;
+    transfer->build_costs.push_back(recipe);
+    transfer->mine_bonus = 0.0;
+    transfer->unique = false;
+    transfer->occupies_grid = true;
+    transfer->removable = true;
+    this->register_definition(transfer);
+
+    ft_sharedptr<ft_building_definition> generator(new ft_building_definition());
+    generator->id = BUILDING_POWER_GENERATOR;
+    generator->name = ft_string("Power Generator");
+    generator->width = 2;
+    generator->height = 2;
+    generator->logistic_cost = 0;
+    generator->logistic_gain = 0;
+    generator->energy_cost = 0.0;
+    generator->energy_gain = 6.0;
+    generator->cycle_time = 0.0;
+    generator->inputs.clear();
+    generator->outputs.clear();
+    generator->build_costs.clear();
+    recipe.key = ORE_COAL;
+    recipe.value = 10;
+    generator->build_costs.push_back(recipe);
+    recipe.key = ORE_COPPER;
+    recipe.value = 8;
+    generator->build_costs.push_back(recipe);
+    generator->mine_bonus = 0.0;
+    generator->unique = false;
+    generator->occupies_grid = true;
+    generator->removable = true;
+    this->register_definition(generator);
+
+    ft_sharedptr<ft_building_definition> upgrade(new ft_building_definition());
+    upgrade->id = BUILDING_UPGRADE_STATION;
+    upgrade->name = ft_string("Mine Upgrade Station");
+    upgrade->width = 2;
+    upgrade->height = 2;
+    upgrade->logistic_cost = 0;
+    upgrade->logistic_gain = 0;
+    upgrade->energy_cost = 1.0;
+    upgrade->energy_gain = 0.0;
+    upgrade->cycle_time = 0.0;
+    upgrade->inputs.clear();
+    upgrade->outputs.clear();
+    upgrade->build_costs.clear();
+    recipe.key = ORE_IRON;
+    recipe.value = 10;
+    upgrade->build_costs.push_back(recipe);
+    recipe.key = ORE_MITHRIL;
+    recipe.value = 4;
+    upgrade->build_costs.push_back(recipe);
+    upgrade->mine_bonus = 0.15;
+    upgrade->unique = false;
+    upgrade->occupies_grid = true;
+    upgrade->removable = true;
+    this->register_definition(upgrade);
+}
+
+void BuildingManager::register_definition(const ft_sharedptr<ft_building_definition> &definition)
+{
+    this->_definitions.insert(definition->id, definition);
+}
+
+const ft_building_definition *BuildingManager::get_definition(int building_id) const
+{
+    const Pair<int, ft_sharedptr<ft_building_definition> > *entry = this->_definitions.find(building_id);
+    if (entry == ft_nullptr)
+        return ft_nullptr;
+    return entry->value.get();
+}
+
+ft_planet_build_state *BuildingManager::get_state(int planet_id)
+{
+    Pair<int, ft_planet_build_state> *entry = this->_planets.find(planet_id);
+    if (entry == ft_nullptr)
+        return ft_nullptr;
+    return &entry->value;
+}
+
+const ft_planet_build_state *BuildingManager::get_state(int planet_id) const
+{
+    const Pair<int, ft_planet_build_state> *entry = this->_planets.find(planet_id);
+    if (entry == ft_nullptr)
+        return ft_nullptr;
+    return &entry->value;
+}
+
+bool BuildingManager::is_area_free(const ft_planet_build_state &state, int x, int y, int width, int height) const
+{
+    if (x < 0 || y < 0 || width <= 0 || height <= 0)
+        return false;
+    if (x + width > state.width || y + height > state.height)
+        return false;
+    for (int dy = 0; dy < height; ++dy)
+    {
+        for (int dx = 0; dx < width; ++dx)
+        {
+            int index = (y + dy) * state.width + (x + dx);
+            if (index < 0 || index >= static_cast<int>(state.grid.size()))
+                return false;
+            if (state.grid[index] != 0)
+                return false;
+        }
+    }
+    return true;
+}
+
+void BuildingManager::occupy_area(ft_planet_build_state &state, int instance_id, int x, int y, int width, int height)
+{
+    for (int dy = 0; dy < height; ++dy)
+    {
+        for (int dx = 0; dx < width; ++dx)
+        {
+            int index = (y + dy) * state.width + (x + dx);
+            if (index >= 0 && index < static_cast<int>(state.grid.size()))
+                state.grid[index] = instance_id;
+        }
+    }
+    state.used_plots += width * height;
+}
+
+void BuildingManager::clear_area(ft_planet_build_state &state, int instance_id)
+{
+    int cleared = 0;
+    for (size_t i = 0; i < state.grid.size(); ++i)
+    {
+        if (state.grid[i] == instance_id)
+        {
+            state.grid[i] = 0;
+            ++cleared;
+        }
+    }
+    if (cleared > 0 && state.used_plots >= cleared)
+        state.used_plots -= cleared;
+}
+
+void BuildingManager::recalculate_planet_statistics(ft_planet_build_state &state)
+{
+    state.logistic_capacity = state.base_logistic;
+    state.energy_generation = state.base_energy_generation;
+    state.support_energy = 0.0;
+    state.mine_multiplier = 1.0;
+    size_t count = state.instances.size();
+    Pair<int, ft_building_instance> *entries = state.instances.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_building_instance &instance = entries[i].value;
+        const ft_building_definition *definition = this->get_definition(instance.definition_id);
+        if (definition == ft_nullptr)
+            continue;
+        state.logistic_capacity += definition->logistic_gain;
+        state.energy_generation += definition->energy_gain;
+        state.mine_multiplier += definition->mine_bonus;
+        if (definition->energy_cost > 0.0 && (definition->cycle_time <= 0.0 || definition->outputs.size() == 0))
+            state.support_energy += definition->energy_cost;
+    }
+    if (state.mine_multiplier < 1.0)
+        state.mine_multiplier = 1.0;
+    state.energy_consumption = state.support_energy;
+    state.logistic_usage = 0;
+}
+
+bool BuildingManager::check_build_costs(const Game &game, int planet_id, const ft_vector<Pair<int, int> > &costs) const
+{
+    for (size_t i = 0; i < costs.size(); ++i)
+    {
+        int resource_id = costs[i].key;
+        int required = costs[i].value;
+        if (required <= 0)
+            continue;
+        int available = game.get_ore(planet_id, resource_id);
+        if (available < required)
+            return false;
+    }
+    return true;
+}
+
+void BuildingManager::pay_build_costs(Game &game, int planet_id, const ft_vector<Pair<int, int> > &costs)
+{
+    for (size_t i = 0; i < costs.size(); ++i)
+    {
+        int resource_id = costs[i].key;
+        int amount = costs[i].value;
+        if (amount <= 0)
+            continue;
+        game.sub_ore(planet_id, resource_id, amount);
+    }
+}
+
+bool BuildingManager::consume_inputs(Game &game, int planet_id, const ft_vector<Pair<int, int> > &inputs)
+{
+    for (size_t i = 0; i < inputs.size(); ++i)
+    {
+        int resource_id = inputs[i].key;
+        int amount = inputs[i].value;
+        if (amount <= 0)
+            continue;
+        if (game.get_ore(planet_id, resource_id) < amount)
+            return false;
+    }
+    for (size_t i = 0; i < inputs.size(); ++i)
+    {
+        int resource_id = inputs[i].key;
+        int amount = inputs[i].value;
+        if (amount > 0)
+            game.sub_ore(planet_id, resource_id, amount);
+    }
+    return true;
+}
+
+void BuildingManager::produce_outputs(Game &game, int planet_id, const ft_vector<Pair<int, int> > &outputs)
+{
+    for (size_t i = 0; i < outputs.size(); ++i)
+    {
+        int resource_id = outputs[i].key;
+        int amount = outputs[i].value;
+        if (amount > 0)
+            game.add_ore(planet_id, resource_id, amount);
+    }
+}
+
+void BuildingManager::ensure_outputs_registered(Game &game, int planet_id, const ft_vector<Pair<int, int> > &outputs)
+{
+    for (size_t i = 0; i < outputs.size(); ++i)
+    {
+        int resource_id = outputs[i].key;
+        game.ensure_planet_item_slot(planet_id, resource_id);
+    }
+}
+
+void BuildingManager::initialize_planet(Game &game, int planet_id)
+{
+    if (this->_planets.find(planet_id) != ft_nullptr)
+        return ;
+    ft_planet_build_state state;
+    state.planet_id = planet_id;
+    state.base_logistic = 1;
+    state.base_energy_generation = 0.0;
+    if (planet_id == PLANET_TERRA)
+    {
+        state.width = 4;
+        state.height = 4;
+    }
+    else if (planet_id == PLANET_MARS)
+    {
+        state.width = 3;
+        state.height = 3;
+    }
+    else if (planet_id == PLANET_ZALTHOR)
+    {
+        state.width = 3;
+        state.height = 4;
+    }
+    else if (planet_id == PLANET_VULCAN)
+    {
+        state.width = 4;
+        state.height = 4;
+    }
+    else
+    {
+        state.width = 4;
+        state.height = 5;
+    }
+    state.grid.resize(state.width * state.height);
+    for (size_t i = 0; i < state.grid.size(); ++i)
+        state.grid[i] = 0;
+    state.used_plots = 0;
+    state.next_instance_id = 1;
+    this->_planets.insert(planet_id, state);
+    Pair<int, ft_planet_build_state> *entry = this->_planets.find(planet_id);
+    if (entry == ft_nullptr)
+        return ;
+    ft_planet_build_state &stored = entry->value;
+    stored.grid = state.grid;
+    stored.width = state.width;
+    stored.height = state.height;
+    stored.base_logistic = state.base_logistic;
+    stored.base_energy_generation = state.base_energy_generation;
+    stored.used_plots = 0;
+    stored.next_instance_id = 1;
+    const ft_building_definition *mine = this->get_definition(BUILDING_MINE_CORE);
+    if (mine != ft_nullptr)
+    {
+        if (mine->occupies_grid)
+            this->occupy_area(stored, stored.next_instance_id, 0, 0, mine->width, mine->height);
+        ft_building_instance instance;
+        instance.uid = stored.next_instance_id++;
+        instance.definition_id = BUILDING_MINE_CORE;
+        instance.x = 0;
+        instance.y = 0;
+        instance.progress = 0.0;
+        instance.active = false;
+        stored.instances.insert(instance.uid, instance);
+    }
+    recalculate_planet_statistics(stored);
+    game.ensure_planet_item_slot(planet_id, ITEM_IRON_BAR);
+    game.ensure_planet_item_slot(planet_id, ITEM_COPPER_BAR);
+    game.ensure_planet_item_slot(planet_id, ITEM_MITHRIL_BAR);
+    game.ensure_planet_item_slot(planet_id, ITEM_ENGINE_PART);
+}
+
+int BuildingManager::place_building(Game &game, int planet_id, int building_id, int x, int y)
+{
+    ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0;
+    const ft_building_definition *definition = this->get_definition(building_id);
+    if (definition == ft_nullptr)
+        return 0;
+    if (definition->unique && this->get_building_count(planet_id, building_id) > 0)
+        return 0;
+    if (definition->occupies_grid && !this->is_area_free(*state, x, y, definition->width, definition->height))
+        return 0;
+    if (!this->check_build_costs(game, planet_id, definition->build_costs))
+        return 0;
+    this->pay_build_costs(game, planet_id, definition->build_costs);
+    if (definition->occupies_grid)
+        this->occupy_area(*state, state->next_instance_id, x, y, definition->width, definition->height);
+    ft_building_instance instance;
+    instance.uid = state->next_instance_id++;
+    instance.definition_id = building_id;
+    instance.x = x;
+    instance.y = y;
+    instance.progress = 0.0;
+    instance.active = false;
+    state->instances.insert(instance.uid, instance);
+    this->ensure_outputs_registered(game, planet_id, definition->outputs);
+    recalculate_planet_statistics(*state);
+    return instance.uid;
+}
+
+bool BuildingManager::remove_building(Game &game, int planet_id, int instance_id)
+{
+    (void)game;
+    ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return false;
+    Pair<int, ft_building_instance> *entry = state->instances.find(instance_id);
+    if (entry == ft_nullptr)
+        return false;
+    const ft_building_definition *definition = this->get_definition(entry->value.definition_id);
+    if (definition == ft_nullptr)
+        return false;
+    if (!definition->removable)
+        return false;
+    this->clear_area(*state, instance_id);
+    state->instances.remove(instance_id);
+    recalculate_planet_statistics(*state);
+    return true;
+}
+
+bool BuildingManager::can_place_building(const Game &game, int planet_id, int building_id, int x, int y) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return false;
+    const ft_building_definition *definition = this->get_definition(building_id);
+    if (definition == ft_nullptr)
+        return false;
+    if (definition->unique && this->get_building_count(planet_id, building_id) > 0)
+        return false;
+    if (definition->occupies_grid && !this->is_area_free(*state, x, y, definition->width, definition->height))
+        return false;
+    if (!this->check_build_costs(game, planet_id, definition->build_costs))
+        return false;
+    return true;
+}
+
+int BuildingManager::get_building_instance(int planet_id, int x, int y) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0;
+    if (x < 0 || y < 0 || x >= state->width || y >= state->height)
+        return 0;
+    int index = y * state->width + x;
+    if (index < 0 || index >= static_cast<int>(state->grid.size()))
+        return 0;
+    return state->grid[index];
+}
+
+int BuildingManager::get_building_count(int planet_id, int building_id) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0;
+    int count = 0;
+    size_t total = state->instances.size();
+    const Pair<int, ft_building_instance> *entries = state->instances.end();
+    entries -= total;
+    for (size_t i = 0; i < total; ++i)
+    {
+        if (entries[i].value.definition_id == building_id)
+            ++count;
+    }
+    return count;
+}
+
+int BuildingManager::get_planet_plot_capacity(int planet_id) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0;
+    return state->width * state->height;
+}
+
+int BuildingManager::get_planet_plot_usage(int planet_id) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0;
+    return state->used_plots;
+}
+
+int BuildingManager::get_planet_logistic_capacity(int planet_id) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0;
+    return state->logistic_capacity;
+}
+
+int BuildingManager::get_planet_logistic_usage(int planet_id) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0;
+    return state->logistic_usage;
+}
+
+double BuildingManager::get_planet_energy_generation(int planet_id) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0.0;
+    return state->energy_generation;
+}
+
+double BuildingManager::get_planet_energy_consumption(int planet_id) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 0.0;
+    return state->energy_consumption;
+}
+
+double BuildingManager::get_mine_multiplier(int planet_id) const
+{
+    const ft_planet_build_state *state = this->get_state(planet_id);
+    if (state == ft_nullptr)
+        return 1.0;
+    return state->mine_multiplier;
+}
+
+void BuildingManager::tick_planet(Game &game, ft_planet_build_state &state, double seconds)
+{
+    state.energy_consumption = state.support_energy;
+    if (state.energy_consumption > state.energy_generation)
+        state.energy_consumption = state.energy_generation;
+    state.logistic_usage = 0;
+    size_t total = state.instances.size();
+    Pair<int, ft_building_instance> *entries = state.instances.end();
+    entries -= total;
+    for (size_t i = 0; i < total; ++i)
+        entries[i].value.active = false;
+    for (size_t i = 0; i < total; ++i)
+    {
+        ft_building_instance &instance = entries[i].value;
+        const ft_building_definition *definition = this->get_definition(instance.definition_id);
+        if (definition == ft_nullptr)
+            continue;
+        if (definition->cycle_time <= 0.0 || definition->outputs.size() == 0)
+            continue;
+        bool can_run = true;
+        if (definition->logistic_cost > 0)
+        {
+            if (state.logistic_usage + definition->logistic_cost > state.logistic_capacity)
+                can_run = false;
+        }
+        if (definition->energy_cost > 0.0)
+        {
+            double projected = state.energy_consumption + definition->energy_cost;
+            if (projected > state.energy_generation + 0.0001)
+                can_run = false;
+        }
+        if (!can_run)
+        {
+            instance.progress = definition->cycle_time;
+            continue;
+        }
+        instance.active = true;
+        state.logistic_usage += definition->logistic_cost;
+        state.energy_consumption += definition->energy_cost;
+    }
+    for (size_t i = 0; i < total; ++i)
+    {
+        ft_building_instance &instance = entries[i].value;
+        const ft_building_definition *definition = this->get_definition(instance.definition_id);
+        if (definition == ft_nullptr)
+            continue;
+        if (definition->cycle_time <= 0.0 || definition->outputs.size() == 0)
+            continue;
+        if (!instance.active)
+            continue;
+        instance.progress += seconds;
+        while (instance.progress >= definition->cycle_time)
+        {
+            if (!this->consume_inputs(game, state.planet_id, definition->inputs))
+            {
+                instance.progress = definition->cycle_time;
+                break;
+            }
+            instance.progress -= definition->cycle_time;
+            this->produce_outputs(game, state.planet_id, definition->outputs);
+        }
+    }
+}
+
+void BuildingManager::tick(Game &game, double seconds)
+{
+    size_t count = this->_planets.size();
+    Pair<int, ft_planet_build_state> *entries = this->_planets.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+        this->tick_planet(game, entries[i].value, seconds);
+}

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -1,0 +1,121 @@
+#ifndef BUILDINGS_HPP
+#define BUILDINGS_HPP
+
+#include "planets.hpp"
+#include "../libft/Template/map.hpp"
+#include "../libft/Template/vector.hpp"
+#include "../libft/Template/pair.hpp"
+#include "../libft/Template/shared_ptr.hpp"
+#include "../libft/Libft/ft_string.hpp"
+
+class Game;
+
+enum e_building_id
+{
+    BUILDING_MINE_CORE = 1,
+    BUILDING_SMELTER,
+    BUILDING_PROCESSOR,
+    BUILDING_CRAFTING_BAY,
+    BUILDING_CONVEYOR,
+    BUILDING_TRANSFER_NODE,
+    BUILDING_POWER_GENERATOR,
+    BUILDING_UPGRADE_STATION
+};
+
+struct ft_building_definition
+{
+    int                         id;
+    ft_string                   name;
+    int                         width;
+    int                         height;
+    int                         logistic_cost;
+    int                         logistic_gain;
+    double                      energy_cost;
+    double                      energy_gain;
+    double                      cycle_time;
+    ft_vector<Pair<int, int> >  inputs;
+    ft_vector<Pair<int, int> >  outputs;
+    ft_vector<Pair<int, int> >  build_costs;
+    double                      mine_bonus;
+    bool                        unique;
+    bool                        occupies_grid;
+    bool                        removable;
+};
+
+struct ft_building_instance
+{
+    int     uid;
+    int     definition_id;
+    int     x;
+    int     y;
+    double  progress;
+    bool    active;
+    ft_building_instance() : uid(0), definition_id(0), x(0), y(0), progress(0.0), active(false) {}
+};
+
+struct ft_planet_build_state
+{
+    int                         planet_id;
+    int                         width;
+    int                         height;
+    int                         base_logistic;
+    int                         used_plots;
+    int                         logistic_capacity;
+    int                         logistic_usage;
+    double                      base_energy_generation;
+    double                      energy_generation;
+    double                      energy_consumption;
+    double                      support_energy;
+    double                      mine_multiplier;
+    int                         next_instance_id;
+    ft_vector<int>              grid;
+    ft_map<int, ft_building_instance> instances;
+
+    ft_planet_build_state();
+};
+
+class BuildingManager
+{
+private:
+    ft_map<int, ft_sharedptr<ft_building_definition> > _definitions;
+    ft_map<int, ft_planet_build_state>                  _planets;
+
+    void register_definition(const ft_sharedptr<ft_building_definition> &definition);
+    const ft_building_definition *get_definition(int building_id) const;
+    bool is_area_free(const ft_planet_build_state &state, int x, int y, int width, int height) const;
+    void occupy_area(ft_planet_build_state &state, int instance_id, int x, int y, int width, int height);
+    void clear_area(ft_planet_build_state &state, int instance_id);
+    void recalculate_planet_statistics(ft_planet_build_state &state);
+    bool check_build_costs(const Game &game, int planet_id, const ft_vector<Pair<int, int> > &costs) const;
+    void pay_build_costs(Game &game, int planet_id, const ft_vector<Pair<int, int> > &costs);
+    bool consume_inputs(Game &game, int planet_id, const ft_vector<Pair<int, int> > &inputs);
+    void produce_outputs(Game &game, int planet_id, const ft_vector<Pair<int, int> > &outputs);
+    void ensure_outputs_registered(Game &game, int planet_id, const ft_vector<Pair<int, int> > &outputs);
+    void tick_planet(Game &game, ft_planet_build_state &state, double seconds);
+    ft_planet_build_state *get_state(int planet_id);
+    const ft_planet_build_state *get_state(int planet_id) const;
+
+public:
+    BuildingManager();
+
+    void initialize_planet(Game &game, int planet_id);
+
+    int place_building(Game &game, int planet_id, int building_id, int x, int y);
+    bool remove_building(Game &game, int planet_id, int instance_id);
+    bool can_place_building(const Game &game, int planet_id, int building_id, int x, int y) const;
+
+    int get_building_instance(int planet_id, int x, int y) const;
+    int get_building_count(int planet_id, int building_id) const;
+
+    int get_planet_plot_capacity(int planet_id) const;
+    int get_planet_plot_usage(int planet_id) const;
+    int get_planet_logistic_capacity(int planet_id) const;
+    int get_planet_logistic_usage(int planet_id) const;
+    double get_planet_energy_generation(int planet_id) const;
+    double get_planet_energy_consumption(int planet_id) const;
+    double get_mine_multiplier(int planet_id) const;
+
+    void tick(Game &game, double seconds);
+};
+
+#endif

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1,0 +1,238 @@
+#include "combat.hpp"
+
+CombatManager::CombatManager()
+{
+    return ;
+}
+
+bool CombatManager::start_raider_assault(int planet_id, double difficulty)
+{
+    if (difficulty <= 0.0)
+        difficulty = 1.0;
+    Pair<int, ft_combat_encounter> *existing = this->_encounters.find(planet_id);
+    if (existing != ft_nullptr && existing->value.active)
+        return false;
+    if (existing != ft_nullptr)
+        this->_encounters.remove(planet_id);
+    ft_combat_encounter encounter;
+    encounter.planet_id = planet_id;
+    encounter.raider_shield = 80.0 * difficulty;
+    encounter.raider_hull = 220.0 * difficulty;
+    encounter.base_damage = 18.0 * difficulty;
+    encounter.elapsed = 0.0;
+    encounter.active = true;
+    this->_encounters.insert(planet_id, encounter);
+    return true;
+}
+
+bool CombatManager::add_fleet(int planet_id, int fleet_id)
+{
+    Pair<int, ft_combat_encounter> *entry = this->_encounters.find(planet_id);
+    if (entry == ft_nullptr || !entry->value.active)
+        return false;
+    ft_sharedptr<ft_vector<int> > &fleets_ptr = entry->value.fleet_ids;
+    if (!fleets_ptr)
+        fleets_ptr = ft_sharedptr<ft_vector<int> >(new ft_vector<int>());
+    ft_vector<int> &fleets = *fleets_ptr;
+    for (size_t i = 0; i < fleets.size(); ++i)
+    {
+        if (fleets[i] == fleet_id)
+            return true;
+    }
+    fleets.push_back(fleet_id);
+    return true;
+}
+
+bool CombatManager::set_support(int planet_id, bool sunflare_docked,
+    bool repair_drones_active, bool shield_generator_online)
+{
+    Pair<int, ft_combat_encounter> *entry = this->_encounters.find(planet_id);
+    if (entry == ft_nullptr || !entry->value.active)
+        return false;
+    entry->value.modifiers.sunflare_docked = sunflare_docked;
+    entry->value.modifiers.repair_drones_active = repair_drones_active;
+    entry->value.modifiers.shield_generator_online = shield_generator_online;
+    return true;
+}
+
+bool CombatManager::is_assault_active(int planet_id) const
+{
+    const Pair<int, ft_combat_encounter> *entry = this->_encounters.find(planet_id);
+    return entry != ft_nullptr && entry->value.active;
+}
+
+double CombatManager::get_raider_shield(int planet_id) const
+{
+    const Pair<int, ft_combat_encounter> *entry = this->_encounters.find(planet_id);
+    if (entry == ft_nullptr || !entry->value.active)
+        return 0.0;
+    return entry->value.raider_shield;
+}
+
+double CombatManager::get_raider_hull(int planet_id) const
+{
+    const Pair<int, ft_combat_encounter> *entry = this->_encounters.find(planet_id);
+    if (entry == ft_nullptr || !entry->value.active)
+        return 0.0;
+    return entry->value.raider_hull;
+}
+
+double CombatManager::get_elapsed(int planet_id) const
+{
+    const Pair<int, ft_combat_encounter> *entry = this->_encounters.find(planet_id);
+    if (entry == ft_nullptr || !entry->value.active)
+        return 0.0;
+    return entry->value.elapsed;
+}
+
+void CombatManager::gather_defenders(const ft_combat_encounter &encounter,
+    ft_map<int, ft_sharedptr<ft_fleet> > &fleets,
+    ft_map<int, ft_sharedptr<ft_fleet> > &planet_fleets,
+    ft_vector<ft_sharedptr<ft_fleet> > &out) const
+{
+    if (encounter.fleet_ids)
+    {
+        const ft_vector<int> &ids = *encounter.fleet_ids;
+        size_t count = ids.size();
+        for (size_t i = 0; i < count; ++i)
+        {
+            int fleet_id = ids[i];
+            Pair<int, ft_sharedptr<ft_fleet> > *entry = fleets.find(fleet_id);
+            if (entry != ft_nullptr && entry->value)
+                out.push_back(entry->value);
+        }
+    }
+    Pair<int, ft_sharedptr<ft_fleet> > *garrison = planet_fleets.find(encounter.planet_id);
+    if (garrison != ft_nullptr && garrison->value)
+        out.push_back(garrison->value);
+}
+
+double CombatManager::calculate_player_power(const ft_vector<ft_sharedptr<ft_fleet> > &defenders) const
+{
+    double power = 0.0;
+    size_t count = defenders.size();
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (!defenders[i])
+            continue;
+        power += defenders[i]->get_attack_power();
+    }
+    return power;
+}
+
+void CombatManager::apply_support(const ft_combat_encounter &encounter,
+    ft_vector<ft_sharedptr<ft_fleet> > &defenders,
+    double seconds)
+{
+    if ((!encounter.modifiers.sunflare_docked && !encounter.modifiers.repair_drones_active)
+        || seconds <= 0.0)
+        return ;
+    int shield_bonus = 0;
+    int repair_bonus = 0;
+    if (encounter.modifiers.sunflare_docked)
+        shield_bonus = static_cast<int>(seconds * 8.0 + 0.5);
+    if (encounter.modifiers.repair_drones_active)
+        repair_bonus = static_cast<int>(seconds * 10.0 + 0.5);
+    size_t count = defenders.size();
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (!defenders[i])
+            continue;
+        defenders[i]->apply_support(shield_bonus, repair_bonus);
+    }
+}
+
+void CombatManager::tick(double seconds, ft_map<int, ft_sharedptr<ft_fleet> > &fleets,
+    ft_map<int, ft_sharedptr<ft_fleet> > &planet_fleets,
+    ft_vector<int> &completed, ft_vector<int> &failed)
+{
+    if (seconds < 0.0)
+        seconds = 0.0;
+    size_t count = this->_encounters.size();
+    if (count == 0)
+        return ;
+    Pair<int, ft_combat_encounter> *entries = this->_encounters.end();
+    entries -= count;
+    ft_vector<int> to_remove;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_combat_encounter &encounter = entries[i].value;
+        if (!encounter.active)
+            continue;
+        encounter.elapsed += seconds;
+        ft_vector<ft_sharedptr<ft_fleet> > defenders;
+        this->gather_defenders(encounter, fleets, planet_fleets, defenders);
+        if (defenders.size() == 0)
+        {
+            failed.push_back(encounter.planet_id);
+            to_remove.push_back(entries[i].key);
+            continue;
+        }
+        double player_damage = this->calculate_player_power(defenders) * seconds;
+        if (player_damage > 0.0)
+        {
+            if (player_damage >= encounter.raider_shield)
+            {
+                player_damage -= encounter.raider_shield;
+                encounter.raider_shield = 0.0;
+            }
+            else
+            {
+                encounter.raider_shield -= player_damage;
+                player_damage = 0.0;
+            }
+            if (player_damage > 0.0)
+            {
+                if (player_damage >= encounter.raider_hull)
+                    encounter.raider_hull = 0.0;
+                else
+                    encounter.raider_hull -= player_damage;
+            }
+        }
+        if (encounter.raider_hull <= 0.0)
+        {
+            completed.push_back(encounter.planet_id);
+            to_remove.push_back(entries[i].key);
+            continue;
+        }
+        double intensity = 1.0 + encounter.elapsed / 45.0;
+        double raider_damage = encounter.base_damage * intensity * seconds;
+        if (encounter.modifiers.shield_generator_online)
+            raider_damage *= 0.8;
+        double leftover = raider_damage;
+        bool defenders_operational = false;
+        size_t defender_count = defenders.size();
+        for (size_t j = 0; j < defender_count && leftover > 0.0; ++j)
+        {
+            ft_sharedptr<ft_fleet> &fleet = defenders[j];
+            if (!fleet)
+                continue;
+            if (fleet->has_operational_ships())
+                defenders_operational = true;
+            leftover = fleet->absorb_damage(leftover);
+        }
+        if (!defenders_operational || leftover > 0.0)
+        {
+            failed.push_back(encounter.planet_id);
+            to_remove.push_back(entries[i].key);
+            continue;
+        }
+        this->apply_support(encounter, defenders, seconds);
+        bool any_active = false;
+        for (size_t j = 0; j < defender_count; ++j)
+        {
+            if (defenders[j] && defenders[j]->has_operational_ships())
+            {
+                any_active = true;
+                break;
+            }
+        }
+        if (!any_active)
+        {
+            failed.push_back(encounter.planet_id);
+            to_remove.push_back(entries[i].key);
+        }
+    }
+    for (size_t i = 0; i < to_remove.size(); ++i)
+        this->_encounters.remove(to_remove[i]);
+}

--- a/src/combat.hpp
+++ b/src/combat.hpp
@@ -1,0 +1,71 @@
+#ifndef COMBAT_HPP
+#define COMBAT_HPP
+
+#include "fleets.hpp"
+#include "../libft/Template/map.hpp"
+#include "../libft/Template/vector.hpp"
+#include "../libft/Template/pair.hpp"
+#include "../libft/Template/shared_ptr.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+struct ft_combat_modifiers
+{
+    bool sunflare_docked;
+    bool repair_drones_active;
+    bool shield_generator_online;
+    ft_combat_modifiers()
+        : sunflare_docked(false),
+          repair_drones_active(false),
+          shield_generator_online(false)
+    {}
+};
+
+class CombatManager
+{
+private:
+    struct ft_combat_encounter
+    {
+        int                     planet_id;
+        ft_sharedptr<ft_vector<int> > fleet_ids;
+        ft_combat_modifiers     modifiers;
+        double                  raider_shield;
+        double                  raider_hull;
+        double                  base_damage;
+        double                  elapsed;
+        bool                    active;
+        ft_combat_encounter()
+            : planet_id(0), fleet_ids(new ft_vector<int>()), modifiers(), raider_shield(0.0),
+              raider_hull(0.0), base_damage(0.0), elapsed(0.0), active(false)
+        {}
+    };
+
+    ft_map<int, ft_combat_encounter> _encounters;
+
+    void gather_defenders(const ft_combat_encounter &encounter,
+        ft_map<int, ft_sharedptr<ft_fleet> > &fleets,
+        ft_map<int, ft_sharedptr<ft_fleet> > &planet_fleets,
+        ft_vector<ft_sharedptr<ft_fleet> > &out) const;
+
+    double calculate_player_power(const ft_vector<ft_sharedptr<ft_fleet> > &defenders) const;
+
+    void apply_support(const ft_combat_encounter &encounter,
+        ft_vector<ft_sharedptr<ft_fleet> > &defenders,
+        double seconds);
+
+public:
+    CombatManager();
+
+    bool start_raider_assault(int planet_id, double difficulty);
+    bool add_fleet(int planet_id, int fleet_id);
+    bool set_support(int planet_id, bool sunflare_docked,
+        bool repair_drones_active, bool shield_generator_online);
+    bool is_assault_active(int planet_id) const;
+    double get_raider_shield(int planet_id) const;
+    double get_raider_hull(int planet_id) const;
+    double get_elapsed(int planet_id) const;
+    void tick(double seconds, ft_map<int, ft_sharedptr<ft_fleet> > &fleets,
+        ft_map<int, ft_sharedptr<ft_fleet> > &planet_fleets,
+        ft_vector<int> &completed, ft_vector<int> &failed);
+};
+
+#endif

--- a/src/fleets.cpp
+++ b/src/fleets.cpp
@@ -1,4 +1,5 @@
 #include "fleets.hpp"
+#include "../libft/Template/vector.hpp"
 
 int ft_fleet::_next_ship_id = 1;
 
@@ -31,6 +32,70 @@ const ft_ship *ft_fleet::find_ship(int ship_uid) const noexcept
 int ft_fleet::get_id() const noexcept
 {
     return this->_id;
+}
+
+int ft_fleet::get_ship_count() const noexcept
+{
+    return static_cast<int>(this->_ships.size());
+}
+
+int ft_fleet::get_total_ship_hp() const noexcept
+{
+    size_t count = this->_ships.size();
+    if (count == 0)
+        return 0;
+    const Pair<int, ft_ship> *entries = this->_ships.end();
+    entries -= count;
+    int total = 0;
+    for (size_t i = 0; i < count; ++i)
+        total += entries[i].value.hp;
+    return total;
+}
+
+int ft_fleet::get_total_ship_shield() const noexcept
+{
+    size_t count = this->_ships.size();
+    if (count == 0)
+        return 0;
+    const Pair<int, ft_ship> *entries = this->_ships.end();
+    entries -= count;
+    int total = 0;
+    for (size_t i = 0; i < count; ++i)
+        total += entries[i].value.shield;
+    return total;
+}
+
+double ft_fleet::get_attack_power() const noexcept
+{
+    size_t count = this->_ships.size();
+    if (count == 0)
+        return 0.0;
+    const Pair<int, ft_ship> *entries = this->_ships.end();
+    entries -= count;
+    double total = 0.0;
+    for (size_t i = 0; i < count; ++i)
+    {
+        const ft_ship &ship = entries[i].value;
+        if (ship.hp <= 0)
+            continue;
+        double base = 4.0;
+        if (ship.type == SHIP_SHIELD)
+            base = 5.0;
+        else if (ship.type == SHIP_RADAR)
+            base = 6.0;
+        else if (ship.type == SHIP_SALVAGE)
+            base = 9.0;
+        else if (ship.type == SHIP_CAPITAL)
+            base = 15.0;
+        double hp_value = static_cast<double>(ship.hp);
+        if (hp_value > 100.0)
+            hp_value = 100.0;
+        double efficiency = hp_value / 100.0;
+        if (efficiency < 0.1)
+            efficiency = 0.1;
+        total += base * efficiency;
+    }
+    return total;
 }
 
 int ft_fleet::create_ship(int ship_type) noexcept
@@ -173,6 +238,123 @@ int ft_fleet::sub_ship_shield(int ship_uid, int amount) noexcept
     if (ship->shield < 0)
         ship->shield = 0;
     return ship->shield;
+}
+
+double ft_fleet::absorb_damage(double damage) noexcept
+{
+    if (damage <= 0.0)
+        return 0.0;
+    int total_damage = static_cast<int>(damage + 0.5);
+    if (total_damage <= 0)
+        return 0.0;
+    ft_vector<ft_ship*> active;
+    size_t count = this->_ships.size();
+    Pair<int, ft_ship> *entries = this->_ships.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_ship &ship = entries[i].value;
+        if (ship.hp > 0 || ship.shield > 0)
+            active.push_back(&ship);
+    }
+    if (active.size() == 0)
+        return static_cast<double>(total_damage);
+    for (size_t i = 0; i < active.size() && total_damage > 0; ++i)
+    {
+        ft_ship *ship = active[i];
+        size_t defenders_left = active.size() - i;
+        int share = total_damage / static_cast<int>(defenders_left);
+        if (share <= 0)
+            share = 1;
+        if (share > total_damage)
+            share = total_damage;
+        total_damage -= share;
+        int remaining = share;
+        if (ship->shield >= remaining)
+        {
+            ship->shield -= remaining;
+            remaining = 0;
+        }
+        else
+        {
+            remaining -= ship->shield;
+            ship->shield = 0;
+        }
+        if (remaining <= 0)
+            continue;
+        double reduction = static_cast<double>(ship->armor) * 0.01;
+        if (reduction > 0.6)
+            reduction = 0.6;
+        double hull_damage_d = static_cast<double>(remaining) * (1.0 - reduction);
+        int hull_damage = static_cast<int>(hull_damage_d + 0.5);
+        if (hull_damage <= 0 && ship->hp > 0)
+            hull_damage = 1;
+        if (hull_damage > ship->hp)
+            hull_damage = ship->hp;
+        ship->hp -= hull_damage;
+    }
+    return static_cast<double>(total_damage);
+}
+
+void ft_fleet::apply_support(int shield_amount, int repair_amount) noexcept
+{
+    if (shield_amount <= 0 && repair_amount <= 0)
+        return ;
+    ft_vector<ft_ship*> shield_targets;
+    ft_vector<ft_ship*> repair_targets;
+    size_t count = this->_ships.size();
+    Pair<int, ft_ship> *entries = this->_ships.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_ship &ship = entries[i].value;
+        if (ship.hp > 0 || ship.shield > 0)
+            shield_targets.push_back(&ship);
+        if (ship.hp > 0)
+            repair_targets.push_back(&ship);
+    }
+    int shield_remaining = shield_amount;
+    for (size_t i = 0; i < shield_targets.size() && shield_remaining > 0; ++i)
+    {
+        ft_ship *ship = shield_targets[i];
+        size_t remain = shield_targets.size() - i;
+        int share = shield_remaining / static_cast<int>(remain);
+        if (share <= 0)
+            share = 1;
+        if (share > shield_remaining)
+            share = shield_remaining;
+        ship->shield += share;
+        shield_remaining -= share;
+    }
+    int repair_remaining = repair_amount;
+    for (size_t i = 0; i < repair_targets.size() && repair_remaining > 0; ++i)
+    {
+        ft_ship *ship = repair_targets[i];
+        size_t remain = repair_targets.size() - i;
+        int share = repair_remaining / static_cast<int>(remain);
+        if (share <= 0)
+            share = 1;
+        if (share > repair_remaining)
+            share = repair_remaining;
+        ship->hp += share;
+        repair_remaining -= share;
+    }
+}
+
+bool ft_fleet::has_operational_ships() const noexcept
+{
+    size_t count = this->_ships.size();
+    if (count == 0)
+        return false;
+    const Pair<int, ft_ship> *entries = this->_ships.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        const ft_ship &ship = entries[i].value;
+        if (ship.hp > 0 || ship.shield > 0)
+            return true;
+    }
+    return false;
 }
 
 void ft_fleet::set_location_planet(int planet_id) noexcept

--- a/src/fleets.hpp
+++ b/src/fleets.hpp
@@ -66,6 +66,10 @@ public:
     explicit ft_fleet(int id) noexcept;
 
     int get_id() const noexcept;
+    int get_ship_count() const noexcept;
+    int get_total_ship_hp() const noexcept;
+    int get_total_ship_shield() const noexcept;
+    double get_attack_power() const noexcept;
 
     int create_ship(int ship_type) noexcept;
     void remove_ship(int ship_uid) noexcept;
@@ -86,6 +90,10 @@ public:
     int get_ship_shield(int ship_uid) const noexcept;
     int add_ship_shield(int ship_uid, int amount) noexcept;
     int sub_ship_shield(int ship_uid, int amount) noexcept;
+
+    double absorb_damage(double damage) noexcept;
+    void apply_support(int shield_amount, int repair_amount) noexcept;
+    bool has_operational_ships() const noexcept;
 
     void set_location_planet(int planet_id) noexcept;
     void set_location_travel(int from, int to, double time) noexcept;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12,16 +12,13 @@ Game::Game(const ft_string &host, const ft_string &path)
     ft_sharedptr<ft_planet> noctaris(new ft_planet_noctaris_prime());
 
     this->_state.add_character(terra);
-    this->_state.add_character(mars);
-    this->_state.add_character(zalthor);
-    this->_state.add_character(vulcan);
-    this->_state.add_character(noctaris);
-
     this->_planets.insert(PLANET_TERRA, terra);
-    this->_planets.insert(PLANET_MARS, mars);
-    this->_planets.insert(PLANET_ZALTHOR, zalthor);
-    this->_planets.insert(PLANET_VULCAN, vulcan);
-    this->_planets.insert(PLANET_NOCTARIS_PRIME, noctaris);
+    this->_buildings.initialize_planet(*this, PLANET_TERRA);
+
+    this->_locked_planets.insert(PLANET_MARS, mars);
+    this->_locked_planets.insert(PLANET_ZALTHOR, zalthor);
+    this->_locked_planets.insert(PLANET_VULCAN, vulcan);
+    this->_locked_planets.insert(PLANET_NOCTARIS_PRIME, noctaris);
 }
 
 Game::~Game()
@@ -46,14 +43,28 @@ void Game::produce(double seconds)
         if (!planet)
             continue;
         ft_vector<Pair<int, int> > produced = planet->produce(seconds);
+        double mine_multiplier = this->_buildings.get_mine_multiplier(planet_id);
         for (size_t j = 0; j < produced.size(); ++j)
+        {
             this->send_state(planet_id, produced[j].key);
+            if (mine_multiplier > 1.0)
+            {
+                double bonus_amount = (mine_multiplier - 1.0) * static_cast<double>(produced[j].value);
+                int bonus = static_cast<int>(bonus_amount);
+                if (bonus > 0)
+                {
+                    planet->add_resource(produced[j].key, bonus);
+                    this->send_state(planet_id, produced[j].key);
+                }
+            }
+        }
     }
 }
 
 void Game::tick(double seconds)
 {
     this->produce(seconds);
+    this->_buildings.tick(*this, seconds);
     size_t count = this->_fleets.size();
     Pair<int, ft_sharedptr<ft_fleet> > *entries = this->_fleets.end();
     entries -= count;
@@ -61,6 +72,62 @@ void Game::tick(double seconds)
     {
         ft_sharedptr<ft_fleet> fleet = entries[i].value;
         fleet->tick(seconds);
+    }
+    ft_vector<int> completed;
+    this->_research.tick(seconds, completed);
+    for (size_t i = 0; i < completed.size(); ++i)
+        this->handle_research_completion(completed[i]);
+
+    ft_quest_context quest_context;
+    this->build_quest_context(quest_context);
+    ft_vector<int> quest_completed;
+    ft_vector<int> quest_failed;
+    ft_vector<int> quest_choices;
+    this->_quests.update(seconds, quest_context, quest_completed, quest_failed, quest_choices);
+    (void)quest_completed;
+    (void)quest_failed;
+    (void)quest_choices;
+
+    ft_vector<int> assault_completed;
+    ft_vector<int> assault_failed;
+    this->_combat.tick(seconds, this->_fleets, this->_planet_fleets, assault_completed, assault_failed);
+    for (size_t i = 0; i < assault_completed.size(); ++i)
+    {
+        int planet_id = assault_completed[i];
+        ft_sharedptr<ft_planet> planet = this->get_planet(planet_id);
+        if (planet)
+        {
+            const ft_vector<Pair<int, double> > &resources = planet->get_resources();
+            if (resources.size() > 0)
+            {
+                int reward_ore = resources[0].key;
+                planet->add_resource(reward_ore, 3);
+                this->send_state(planet_id, reward_ore);
+            }
+        }
+        ft_string entry("Old Miner Joe records a victory at planet ");
+        entry.append(ft_to_string(planet_id));
+        entry.append(ft_string(": the raider fleet was repelled."));
+        this->_lore_log.push_back(entry);
+    }
+    for (size_t i = 0; i < assault_failed.size(); ++i)
+    {
+        int planet_id = assault_failed[i];
+        ft_sharedptr<ft_planet> planet = this->get_planet(planet_id);
+        if (planet)
+        {
+            const ft_vector<Pair<int, double> > &resources = planet->get_resources();
+            if (resources.size() > 0)
+            {
+                int penalty_ore = resources[0].key;
+                planet->sub_resource(penalty_ore, 2);
+                this->send_state(planet_id, penalty_ore);
+            }
+        }
+        ft_string entry("Professor Lumen warns of losses on planet ");
+        entry.append(ft_to_string(planet_id));
+        entry.append(ft_string(": raiders breached the defenses."));
+        this->_lore_log.push_back(entry);
     }
 }
 
@@ -133,6 +200,295 @@ void Game::send_state(int planet_id, int ore_id)
     body.append("}");
     ft_string response;
     this->_backend.send_state(body, response);
+}
+
+void Game::unlock_planet(int planet_id)
+{
+    if (this->_planets.find(planet_id) != ft_nullptr)
+        return ;
+    Pair<int, ft_sharedptr<ft_planet> > *entry = this->_locked_planets.find(planet_id);
+    if (entry == ft_nullptr)
+        return ;
+    ft_sharedptr<ft_planet> planet = entry->value;
+    this->_planets.insert(planet_id, planet);
+    this->_locked_planets.remove(planet_id);
+    this->_state.add_character(planet);
+    this->_buildings.initialize_planet(*this, planet_id);
+    const ft_vector<Pair<int, double> > &resources = planet->get_resources();
+    for (size_t i = 0; i < resources.size(); ++i)
+        this->send_state(planet_id, resources[i].key);
+}
+
+bool Game::can_pay_research_cost(const ft_vector<Pair<int, int> > &costs) const
+{
+    for (size_t i = 0; i < costs.size(); ++i)
+    {
+        int ore_id = costs[i].key;
+        int required = costs[i].value;
+        int total = 0;
+        size_t count = this->_planets.size();
+        const Pair<int, ft_sharedptr<ft_planet> > *entries = this->_planets.end();
+        entries -= count;
+        for (size_t j = 0; j < count; ++j)
+        {
+            const ft_sharedptr<ft_planet> &planet = entries[j].value;
+            total += planet->get_resource(ore_id);
+            if (total >= required)
+                break;
+        }
+        if (total < required)
+            return false;
+    }
+    return true;
+}
+
+void Game::pay_research_cost(const ft_vector<Pair<int, int> > &costs)
+{
+    for (size_t i = 0; i < costs.size(); ++i)
+    {
+        int ore_id = costs[i].key;
+        int remaining = costs[i].value;
+        if (remaining <= 0)
+            continue;
+        size_t count = this->_planets.size();
+        Pair<int, ft_sharedptr<ft_planet> > *entries = this->_planets.end();
+        entries -= count;
+        for (size_t j = 0; j < count && remaining > 0; ++j)
+        {
+            ft_sharedptr<ft_planet> planet = entries[j].value;
+            int available = planet->get_resource(ore_id);
+            if (available <= 0)
+                continue;
+            int take = remaining < available ? remaining : available;
+            planet->sub_resource(ore_id, take);
+            this->send_state(planet->get_id(), ore_id);
+            remaining -= take;
+        }
+    }
+}
+
+void Game::handle_research_completion(int research_id)
+{
+    const ft_research_definition *definition = this->_research.get_definition(research_id);
+    if (definition == ft_nullptr)
+        return ;
+    for (size_t i = 0; i < definition->unlock_planets.size(); ++i)
+        this->unlock_planet(definition->unlock_planets[i]);
+}
+
+void Game::build_quest_context(ft_quest_context &context) const
+{
+    size_t planet_count = this->_planets.size();
+    const Pair<int, ft_sharedptr<ft_planet> > *planet_entries = this->_planets.end();
+    planet_entries -= planet_count;
+    for (size_t i = 0; i < planet_count; ++i)
+    {
+        const ft_sharedptr<ft_planet> &planet = planet_entries[i].value;
+        const ft_vector<Pair<int, double> > &resources = planet->get_resources();
+        for (size_t j = 0; j < resources.size(); ++j)
+        {
+            int ore_id = resources[j].key;
+            int amount = planet->get_resource(ore_id);
+            Pair<int, int> *entry = context.resource_totals.find(ore_id);
+            if (entry == ft_nullptr)
+                context.resource_totals.insert(ore_id, amount);
+            else
+                entry->value += amount;
+        }
+    }
+
+    context.research_status.insert(RESEARCH_UNLOCK_MARS, this->_research.is_completed(RESEARCH_UNLOCK_MARS) ? 1 : 0);
+    context.research_status.insert(RESEARCH_UNLOCK_ZALTHOR, this->_research.is_completed(RESEARCH_UNLOCK_ZALTHOR) ? 1 : 0);
+    context.research_status.insert(RESEARCH_UNLOCK_VULCAN, this->_research.is_completed(RESEARCH_UNLOCK_VULCAN) ? 1 : 0);
+    context.research_status.insert(RESEARCH_UNLOCK_NOCTARIS, this->_research.is_completed(RESEARCH_UNLOCK_NOCTARIS) ? 1 : 0);
+
+    size_t fleet_count = this->_fleets.size();
+    const Pair<int, ft_sharedptr<ft_fleet> > *fleet_entries = this->_fleets.end();
+    fleet_entries -= fleet_count;
+    for (size_t i = 0; i < fleet_count; ++i)
+    {
+        const ft_sharedptr<ft_fleet> &fleet = fleet_entries[i].value;
+        context.total_ship_count += fleet->get_ship_count();
+        context.total_ship_hp += fleet->get_total_ship_hp();
+    }
+    size_t garrison_count = this->_planet_fleets.size();
+    const Pair<int, ft_sharedptr<ft_fleet> > *garrison_entries = this->_planet_fleets.end();
+    garrison_entries -= garrison_count;
+    for (size_t i = 0; i < garrison_count; ++i)
+    {
+        const ft_sharedptr<ft_fleet> &fleet = garrison_entries[i].value;
+        context.total_ship_count += fleet->get_ship_count();
+        context.total_ship_hp += fleet->get_total_ship_hp();
+    }
+}
+
+bool Game::is_planet_unlocked(int planet_id) const
+{
+    const Pair<int, ft_sharedptr<ft_planet> > *entry = this->_planets.find(planet_id);
+    return entry != ft_nullptr;
+}
+
+bool Game::can_place_building(int planet_id, int building_id, int x, int y) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return false;
+    return this->_buildings.can_place_building(*this, planet_id, building_id, x, y);
+}
+
+int Game::place_building(int planet_id, int building_id, int x, int y)
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0;
+    return this->_buildings.place_building(*this, planet_id, building_id, x, y);
+}
+
+bool Game::remove_building(int planet_id, int instance_id)
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return false;
+    return this->_buildings.remove_building(*this, planet_id, instance_id);
+}
+
+int Game::get_building_instance(int planet_id, int x, int y) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0;
+    return this->_buildings.get_building_instance(planet_id, x, y);
+}
+
+int Game::get_building_count(int planet_id, int building_id) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0;
+    return this->_buildings.get_building_count(planet_id, building_id);
+}
+
+int Game::get_planet_plot_capacity(int planet_id) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0;
+    return this->_buildings.get_planet_plot_capacity(planet_id);
+}
+
+int Game::get_planet_plot_usage(int planet_id) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0;
+    return this->_buildings.get_planet_plot_usage(planet_id);
+}
+
+int Game::get_planet_logistic_capacity(int planet_id) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0;
+    return this->_buildings.get_planet_logistic_capacity(planet_id);
+}
+
+int Game::get_planet_logistic_usage(int planet_id) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0;
+    return this->_buildings.get_planet_logistic_usage(planet_id);
+}
+
+double Game::get_planet_energy_generation(int planet_id) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0.0;
+    return this->_buildings.get_planet_energy_generation(planet_id);
+}
+
+double Game::get_planet_energy_consumption(int planet_id) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 0.0;
+    return this->_buildings.get_planet_energy_consumption(planet_id);
+}
+
+double Game::get_planet_mine_multiplier(int planet_id) const
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return 1.0;
+    return this->_buildings.get_mine_multiplier(planet_id);
+}
+
+void Game::ensure_planet_item_slot(int planet_id, int resource_id)
+{
+    ft_sharedptr<ft_planet> planet = this->get_planet(planet_id);
+    if (!planet)
+        return ;
+    planet->ensure_item_slot(resource_id);
+}
+
+bool Game::can_start_research(int research_id) const
+{
+    const ft_research_definition *definition = this->_research.get_definition(research_id);
+    if (definition == ft_nullptr)
+        return false;
+    if (!this->_research.can_start(research_id))
+        return false;
+    return this->can_pay_research_cost(definition->costs);
+}
+
+bool Game::start_research(int research_id)
+{
+    const ft_research_definition *definition = this->_research.get_definition(research_id);
+    if (definition == ft_nullptr)
+        return false;
+    if (!this->_research.can_start(research_id))
+        return false;
+    if (!this->can_pay_research_cost(definition->costs))
+        return false;
+    if (!this->_research.start(research_id))
+        return false;
+    this->pay_research_cost(definition->costs);
+    return true;
+}
+
+int Game::get_research_status(int research_id) const
+{
+    return this->_research.get_status(research_id);
+}
+
+double Game::get_research_time_remaining(int research_id) const
+{
+    return this->_research.get_remaining_time(research_id);
+}
+
+int Game::get_active_quest() const
+{
+    return this->_quests.get_active_quest_id();
+}
+
+int Game::get_quest_status(int quest_id) const
+{
+    return this->_quests.get_status(quest_id);
+}
+
+double Game::get_quest_time_remaining(int quest_id) const
+{
+    return this->_quests.get_time_remaining(quest_id);
+}
+
+bool Game::resolve_quest_choice(int quest_id, int choice_id)
+{
+    if (!this->_quests.make_choice(quest_id, choice_id))
+        return false;
+    ft_quest_context context;
+    this->build_quest_context(context);
+    ft_vector<int> quest_completed;
+    ft_vector<int> quest_failed;
+    ft_vector<int> quest_choices;
+    this->_quests.update(0.0, context, quest_completed, quest_failed, quest_choices);
+    (void)quest_completed;
+    (void)quest_failed;
+    (void)quest_choices;
+    return true;
+}
+
+int Game::get_quest_choice(int quest_id) const
+{
+    return this->_quests.get_choice(quest_id);
 }
 
 int Game::add_ore(int planet_id, int ore_id, int amount)
@@ -414,5 +770,55 @@ ft_location Game::get_planet_fleet_location(int planet_id) const
     if (!fleet)
         return ft_location();
     return fleet->get_location();
+}
+
+bool Game::start_raider_assault(int planet_id, double difficulty)
+{
+    if (!this->is_planet_unlocked(planet_id))
+        return false;
+    if (!this->_combat.start_raider_assault(planet_id, difficulty))
+        return false;
+    this->get_planet_fleet(planet_id);
+    ft_string entry("Navigator Zara signals a raider incursion on planet ");
+    entry.append(ft_to_string(planet_id));
+    entry.append(ft_string(": defenses are mobilizing."));
+    this->_lore_log.push_back(entry);
+    return true;
+}
+
+bool Game::assign_fleet_to_assault(int planet_id, int fleet_id)
+{
+    if (!this->_combat.is_assault_active(planet_id))
+        return false;
+    Pair<int, ft_sharedptr<ft_fleet> > *entry = this->_fleets.find(fleet_id);
+    if (entry == ft_nullptr || !entry->value)
+        return false;
+    return this->_combat.add_fleet(planet_id, fleet_id);
+}
+
+bool Game::set_assault_support(int planet_id, bool sunflare_docked,
+                               bool repair_drones_active, bool shield_generator_online)
+{
+    return this->_combat.set_support(planet_id, sunflare_docked, repair_drones_active, shield_generator_online);
+}
+
+bool Game::is_assault_active(int planet_id) const
+{
+    return this->_combat.is_assault_active(planet_id);
+}
+
+double Game::get_assault_raider_shield(int planet_id) const
+{
+    return this->_combat.get_raider_shield(planet_id);
+}
+
+double Game::get_assault_raider_hull(int planet_id) const
+{
+    return this->_combat.get_raider_hull(planet_id);
+}
+
+const ft_vector<ft_string> &Game::get_lore_log() const
+{
+    return this->_lore_log;
 }
 

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -4,17 +4,28 @@
 #include "backend_client.hpp"
 #include "planets.hpp"
 #include "fleets.hpp"
+#include "research.hpp"
+#include "quests.hpp"
+#include "combat.hpp"
+#include "buildings.hpp"
 #include "../libft/Game/game_state.hpp"
 #include "../libft/Template/map.hpp"
+#include "../libft/Template/vector.hpp"
 
 class Game
 {
 private:
     ft_game_state                                 _state;
     ft_map<int, ft_sharedptr<ft_planet> >         _planets;
+    ft_map<int, ft_sharedptr<ft_planet> >         _locked_planets;
     ft_map<int, ft_sharedptr<ft_fleet> >          _fleets;
     ft_map<int, ft_sharedptr<ft_fleet> >          _planet_fleets;
     BackendClient                                _backend;
+    ResearchManager                              _research;
+    QuestManager                                 _quests;
+    CombatManager                                _combat;
+    BuildingManager                              _buildings;
+    ft_vector<ft_string>                         _lore_log;
 
     ft_sharedptr<ft_planet> get_planet(int id);
     ft_sharedptr<const ft_planet> get_planet(int id) const;
@@ -23,6 +34,11 @@ private:
     ft_sharedptr<ft_fleet> get_planet_fleet(int id);
     ft_sharedptr<const ft_fleet> get_planet_fleet(int id) const;
     void send_state(int planet_id, int ore_id);
+    void unlock_planet(int planet_id);
+    bool can_pay_research_cost(const ft_vector<Pair<int, int> > &costs) const;
+    void pay_research_cost(const ft_vector<Pair<int, int> > &costs);
+    void handle_research_completion(int research_id);
+    void build_quest_context(ft_quest_context &context) const;
 
 public:
     Game(const ft_string &host, const ft_string &path);
@@ -30,6 +46,42 @@ public:
 
     void produce(double seconds);
     void tick(double seconds);
+
+    bool is_planet_unlocked(int planet_id) const;
+
+    bool can_place_building(int planet_id, int building_id, int x, int y) const;
+    int place_building(int planet_id, int building_id, int x, int y);
+    bool remove_building(int planet_id, int instance_id);
+    int get_building_instance(int planet_id, int x, int y) const;
+    int get_building_count(int planet_id, int building_id) const;
+    int get_planet_plot_capacity(int planet_id) const;
+    int get_planet_plot_usage(int planet_id) const;
+    int get_planet_logistic_capacity(int planet_id) const;
+    int get_planet_logistic_usage(int planet_id) const;
+    double get_planet_energy_generation(int planet_id) const;
+    double get_planet_energy_consumption(int planet_id) const;
+    double get_planet_mine_multiplier(int planet_id) const;
+    void ensure_planet_item_slot(int planet_id, int resource_id);
+
+    bool can_start_research(int research_id) const;
+    bool start_research(int research_id);
+    int get_research_status(int research_id) const;
+    double get_research_time_remaining(int research_id) const;
+
+    int get_active_quest() const;
+    int get_quest_status(int quest_id) const;
+    double get_quest_time_remaining(int quest_id) const;
+    bool resolve_quest_choice(int quest_id, int choice_id);
+    int get_quest_choice(int quest_id) const;
+
+    bool start_raider_assault(int planet_id, double difficulty);
+    bool assign_fleet_to_assault(int planet_id, int fleet_id);
+    bool set_assault_support(int planet_id, bool sunflare_docked,
+                             bool repair_drones_active, bool shield_generator_online);
+    bool is_assault_active(int planet_id) const;
+    double get_assault_raider_shield(int planet_id) const;
+    double get_assault_raider_hull(int planet_id) const;
+    const ft_vector<ft_string> &get_lore_log() const;
 
     int add_ore(int planet_id, int ore_id, int amount);
     int sub_ore(int planet_id, int ore_id, int amount);

--- a/src/planets.cpp
+++ b/src/planets.cpp
@@ -5,18 +5,34 @@ ft_planet::ft_planet(int id) noexcept : _id(id)
     this->_inventory.resize(10);
 }
 
-void ft_planet::register_resource(int ore_id, double rate) noexcept
+void ft_planet::ensure_item_slot(int item_id) noexcept
 {
-    ft_sharedptr<ft_item> item(new ft_item());
-    item->set_item_id(ore_id);
-    item->set_max_stack(1000000);
-    item->set_stack_size(0);
-    this->_inventory.add_item(item);
+    ft_sharedptr<ft_item> item = this->find_item(item_id);
+    if (item)
+        return ;
+    ft_sharedptr<ft_item> new_item(new ft_item());
+    new_item->set_item_id(item_id);
+    new_item->set_max_stack(1000000);
+    new_item->set_stack_size(0);
+    this->_inventory.add_item(new_item);
 
     Pair<int, ft_sharedptr<ft_item> > pair_item;
-    pair_item.key = ore_id;
-    pair_item.value = item;
+    pair_item.key = item_id;
+    pair_item.value = new_item;
     this->_items.push_back(pair_item);
+}
+
+void ft_planet::register_resource(int ore_id, double rate) noexcept
+{
+    this->ensure_item_slot(ore_id);
+    for (size_t i = 0; i < this->_rates.size(); ++i)
+    {
+        if (this->_rates[i].key == ore_id)
+        {
+            this->_rates[i].value = rate;
+            return ;
+        }
+    }
 
     Pair<int, double> pair_rate;
     pair_rate.key = ore_id;

--- a/src/planets.hpp
+++ b/src/planets.hpp
@@ -52,6 +52,7 @@ protected:
 
 public:
     explicit ft_planet(int id) noexcept;
+    void ensure_item_slot(int item_id) noexcept;
     void register_resource(int ore_id, double rate) noexcept;
 
     int get_id() const noexcept;

--- a/src/quests.cpp
+++ b/src/quests.cpp
@@ -1,0 +1,378 @@
+#include "quests.hpp"
+
+QuestManager::QuestManager()
+{
+    ft_sharedptr<ft_quest_definition> skirmish(new ft_quest_definition());
+    skirmish->id = QUEST_INITIAL_SKIRMISHES;
+    skirmish->name = ft_string("Initial Raider Skirmishes");
+    skirmish->description = ft_string("Protect supply convoys and fortify Terra's perimeter.");
+    skirmish->time_limit = 0.0;
+    skirmish->requires_choice = false;
+    skirmish->required_choice_quest = 0;
+    skirmish->required_choice_value = 0;
+    ft_quest_objective objective;
+    objective.type = QUEST_OBJECTIVE_RESOURCE_TOTAL;
+    objective.target_id = ORE_IRON;
+    objective.amount = 10;
+    skirmish->objectives.push_back(objective);
+    objective.target_id = ORE_COPPER;
+    objective.amount = 10;
+    skirmish->objectives.push_back(objective);
+    this->register_quest(skirmish);
+
+    ft_sharedptr<ft_quest_definition> defense(new ft_quest_definition());
+    defense->id = QUEST_DEFENSE_OF_TERRA;
+    defense->name = ft_string("Defense of Terra");
+    defense->description = ft_string("Assemble a defensive wing to repel raider assaults.");
+    defense->time_limit = 0.0;
+    defense->requires_choice = false;
+    defense->required_choice_quest = 0;
+    defense->required_choice_value = 0;
+    defense->prerequisites.push_back(QUEST_INITIAL_SKIRMISHES);
+    objective.type = QUEST_OBJECTIVE_FLEET_COUNT;
+    objective.target_id = 0;
+    objective.amount = 2;
+    defense->objectives.push_back(objective);
+    objective.type = QUEST_OBJECTIVE_TOTAL_SHIP_HP;
+    objective.target_id = 0;
+    objective.amount = 120;
+    defense->objectives.push_back(objective);
+    this->register_quest(defense);
+
+    ft_sharedptr<ft_quest_definition> investigate(new ft_quest_definition());
+    investigate->id = QUEST_INVESTIGATE_RAIDERS;
+    investigate->name = ft_string("Investigate Raider Motives");
+    investigate->description = ft_string("Complete research to uncover the raiders' plans.");
+    investigate->time_limit = 0.0;
+    investigate->requires_choice = false;
+    investigate->required_choice_quest = 0;
+    investigate->required_choice_value = 0;
+    investigate->prerequisites.push_back(QUEST_DEFENSE_OF_TERRA);
+    objective.type = QUEST_OBJECTIVE_RESEARCH_COMPLETED;
+    objective.target_id = RESEARCH_UNLOCK_MARS;
+    objective.amount = 1;
+    investigate->objectives.push_back(objective);
+    objective.target_id = RESEARCH_UNLOCK_ZALTHOR;
+    objective.amount = 1;
+    investigate->objectives.push_back(objective);
+    this->register_quest(investigate);
+
+    ft_sharedptr<ft_quest_definition> battle(new ft_quest_definition());
+    battle->id = QUEST_CLIMACTIC_BATTLE;
+    battle->name = ft_string("Climactic Battle");
+    battle->description = ft_string("Prepare the fleets and technology for the climactic assault.");
+    battle->time_limit = 0.0;
+    battle->requires_choice = false;
+    battle->required_choice_quest = 0;
+    battle->required_choice_value = 0;
+    battle->prerequisites.push_back(QUEST_INVESTIGATE_RAIDERS);
+    objective.type = QUEST_OBJECTIVE_RESEARCH_COMPLETED;
+    objective.target_id = RESEARCH_UNLOCK_VULCAN;
+    objective.amount = 1;
+    battle->objectives.push_back(objective);
+    objective.type = QUEST_OBJECTIVE_TOTAL_SHIP_HP;
+    objective.target_id = 0;
+    objective.amount = 180;
+    battle->objectives.push_back(objective);
+    this->register_quest(battle);
+
+    ft_sharedptr<ft_quest_definition> decision(new ft_quest_definition());
+    decision->id = QUEST_CRITICAL_DECISION;
+    decision->name = ft_string("The Critical Decision");
+    decision->description = ft_string("Decide Blackthorne's fate and set the course for the system.");
+    decision->time_limit = 0.0;
+    decision->requires_choice = true;
+    decision->required_choice_quest = 0;
+    decision->required_choice_value = 0;
+    decision->prerequisites.push_back(QUEST_CLIMACTIC_BATTLE);
+    ft_quest_choice_definition choice;
+    choice.choice_id = QUEST_CHOICE_EXECUTE_BLACKTHORNE;
+    choice.description = ft_string("Execute Blackthorne to preserve order.");
+    decision->choices.push_back(choice);
+    choice.choice_id = QUEST_CHOICE_SPARE_BLACKTHORNE;
+    choice.description = ft_string("Spare Blackthorne and investigate corruption.");
+    decision->choices.push_back(choice);
+    this->register_quest(decision);
+
+    ft_sharedptr<ft_quest_definition> order(new ft_quest_definition());
+    order->id = QUEST_ORDER_UPRISING;
+    order->name = ft_string("Order's Last Stand");
+    order->description = ft_string("Crush the uprising that rises after Blackthorne's execution.");
+    order->time_limit = 0.0;
+    order->requires_choice = false;
+    order->required_choice_quest = QUEST_CRITICAL_DECISION;
+    order->required_choice_value = QUEST_CHOICE_EXECUTE_BLACKTHORNE;
+    order->prerequisites.push_back(QUEST_CRITICAL_DECISION);
+    objective.type = QUEST_OBJECTIVE_RESOURCE_TOTAL;
+    objective.target_id = ORE_COAL;
+    objective.amount = 20;
+    order->objectives.push_back(objective);
+    this->register_quest(order);
+
+    ft_sharedptr<ft_quest_definition> rebellion(new ft_quest_definition());
+    rebellion->id = QUEST_REBELLION_FLEET;
+    rebellion->name = ft_string("Rebellion Rising");
+    rebellion->description = ft_string("Rally new allies after sparing Blackthorne.");
+    rebellion->time_limit = 0.0;
+    rebellion->requires_choice = false;
+    rebellion->required_choice_quest = QUEST_CRITICAL_DECISION;
+    rebellion->required_choice_value = QUEST_CHOICE_SPARE_BLACKTHORNE;
+    rebellion->prerequisites.push_back(QUEST_CRITICAL_DECISION);
+    objective.type = QUEST_OBJECTIVE_RESEARCH_COMPLETED;
+    objective.target_id = RESEARCH_UNLOCK_NOCTARIS;
+    objective.amount = 1;
+    rebellion->objectives.push_back(objective);
+    objective.type = QUEST_OBJECTIVE_RESOURCE_TOTAL;
+    objective.target_id = ORE_OBSIDIAN;
+    objective.amount = 4;
+    rebellion->objectives.push_back(objective);
+    this->register_quest(rebellion);
+
+    this->update_availability();
+    this->activate_next();
+}
+
+void QuestManager::register_quest(const ft_sharedptr<ft_quest_definition> &definition)
+{
+    this->_definitions.insert(definition->id, definition);
+    ft_quest_progress progress;
+    if (definition->prerequisites.size() == 0 && definition->required_choice_quest == 0)
+        progress.status = QUEST_STATUS_AVAILABLE;
+    else
+        progress.status = QUEST_STATUS_LOCKED;
+    progress.time_remaining = 0.0;
+    this->_progress.insert(definition->id, progress);
+}
+
+void QuestManager::update_availability()
+{
+    size_t count = this->_progress.size();
+    Pair<int, ft_quest_progress> *entries = this->_progress.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_quest_progress &progress = entries[i].value;
+        if (progress.status != QUEST_STATUS_LOCKED)
+            continue;
+        const ft_quest_definition *definition = this->get_definition(entries[i].key);
+        if (definition == ft_nullptr)
+            continue;
+        bool ready = true;
+        for (size_t j = 0; j < definition->prerequisites.size(); ++j)
+        {
+            int prereq = definition->prerequisites[j];
+            const Pair<int, ft_quest_progress> *pr_entry = this->_progress.find(prereq);
+            if (pr_entry == ft_nullptr || pr_entry->value.status != QUEST_STATUS_COMPLETED)
+            {
+                ready = false;
+                break;
+            }
+        }
+        if (!ready)
+            continue;
+        if (definition->required_choice_quest != 0)
+        {
+            const Pair<int, int> *choice_entry = this->_quest_choices.find(definition->required_choice_quest);
+            if (choice_entry == ft_nullptr || choice_entry->value != definition->required_choice_value)
+                continue;
+        }
+        progress.status = QUEST_STATUS_AVAILABLE;
+    }
+}
+
+void QuestManager::activate_next()
+{
+    size_t count = this->_progress.size();
+    if (count == 0)
+        return ;
+    Pair<int, ft_quest_progress> *entries = this->_progress.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (entries[i].value.status == QUEST_STATUS_ACTIVE || entries[i].value.status == QUEST_STATUS_AWAITING_CHOICE)
+            return ;
+    }
+    int next_id = 0;
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (entries[i].value.status == QUEST_STATUS_AVAILABLE)
+        {
+            if (next_id == 0 || entries[i].key < next_id)
+                next_id = entries[i].key;
+        }
+    }
+    if (next_id == 0)
+        return ;
+    Pair<int, ft_quest_progress> *progress_entry = this->_progress.find(next_id);
+    if (progress_entry == ft_nullptr)
+        return ;
+    progress_entry->value.status = QUEST_STATUS_ACTIVE;
+    const ft_quest_definition *definition = this->get_definition(next_id);
+    if (definition != ft_nullptr && definition->time_limit > 0.0)
+        progress_entry->value.time_remaining = definition->time_limit;
+    else
+        progress_entry->value.time_remaining = 0.0;
+}
+
+bool QuestManager::are_objectives_met(const ft_quest_definition &definition, const ft_quest_context &context) const
+{
+    if (definition.objectives.size() == 0)
+        return true;
+    for (size_t i = 0; i < definition.objectives.size(); ++i)
+    {
+        const ft_quest_objective &objective = definition.objectives[i];
+        if (objective.type == QUEST_OBJECTIVE_RESOURCE_TOTAL)
+        {
+            const Pair<int, int> *entry = context.resource_totals.find(objective.target_id);
+            if (entry == ft_nullptr || entry->value < objective.amount)
+                return false;
+        }
+        else if (objective.type == QUEST_OBJECTIVE_RESEARCH_COMPLETED)
+        {
+            const Pair<int, int> *entry = context.research_status.find(objective.target_id);
+            if (entry == ft_nullptr || entry->value < 1)
+                return false;
+        }
+        else if (objective.type == QUEST_OBJECTIVE_FLEET_COUNT)
+        {
+            if (context.total_ship_count < objective.amount)
+                return false;
+        }
+        else if (objective.type == QUEST_OBJECTIVE_TOTAL_SHIP_HP)
+        {
+            if (context.total_ship_hp < objective.amount)
+                return false;
+        }
+    }
+    return true;
+}
+
+void QuestManager::update(double seconds, const ft_quest_context &context,
+                          ft_vector<int> &completed, ft_vector<int> &failed,
+                          ft_vector<int> &awaiting_choice)
+{
+    size_t count = this->_progress.size();
+    Pair<int, ft_quest_progress> *entries = this->_progress.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_quest_progress &progress = entries[i].value;
+        if (progress.status != QUEST_STATUS_ACTIVE)
+            continue;
+        const ft_quest_definition *definition = this->get_definition(entries[i].key);
+        if (definition == ft_nullptr)
+            continue;
+        if (progress.time_remaining > 0.0)
+        {
+            if (progress.time_remaining > seconds)
+                progress.time_remaining -= seconds;
+            else
+            {
+                progress.time_remaining = 0.0;
+                progress.status = QUEST_STATUS_FAILED;
+                failed.push_back(entries[i].key);
+                continue;
+            }
+        }
+        if (this->are_objectives_met(*definition, context))
+        {
+            if (definition->requires_choice)
+            {
+                progress.status = QUEST_STATUS_AWAITING_CHOICE;
+                awaiting_choice.push_back(entries[i].key);
+            }
+            else
+            {
+                progress.status = QUEST_STATUS_COMPLETED;
+                progress.time_remaining = 0.0;
+                completed.push_back(entries[i].key);
+            }
+        }
+    }
+    if (completed.size() > 0 || failed.size() > 0)
+        this->update_availability();
+    this->activate_next();
+}
+
+int QuestManager::get_active_quest_id() const
+{
+    size_t count = this->_progress.size();
+    const Pair<int, ft_quest_progress> *entries = this->_progress.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (entries[i].value.status == QUEST_STATUS_AWAITING_CHOICE)
+            return entries[i].key;
+    }
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (entries[i].value.status == QUEST_STATUS_ACTIVE)
+            return entries[i].key;
+    }
+    return 0;
+}
+
+int QuestManager::get_status(int quest_id) const
+{
+    const Pair<int, ft_quest_progress> *entry = this->_progress.find(quest_id);
+    if (entry == ft_nullptr)
+        return QUEST_STATUS_LOCKED;
+    return entry->value.status;
+}
+
+double QuestManager::get_time_remaining(int quest_id) const
+{
+    const Pair<int, ft_quest_progress> *entry = this->_progress.find(quest_id);
+    if (entry == ft_nullptr)
+        return 0.0;
+    return entry->value.time_remaining;
+}
+
+const ft_quest_definition *QuestManager::get_definition(int quest_id) const
+{
+    const Pair<int, ft_sharedptr<ft_quest_definition> > *entry = this->_definitions.find(quest_id);
+    if (entry == ft_nullptr)
+        return ft_nullptr;
+    return entry->value.get();
+}
+
+bool QuestManager::make_choice(int quest_id, int choice_id)
+{
+    Pair<int, ft_quest_progress> *progress_entry = this->_progress.find(quest_id);
+    if (progress_entry == ft_nullptr)
+        return false;
+    if (progress_entry->value.status != QUEST_STATUS_AWAITING_CHOICE)
+        return false;
+    const ft_quest_definition *definition = this->get_definition(quest_id);
+    if (definition == ft_nullptr)
+        return false;
+    bool valid = false;
+    for (size_t i = 0; i < definition->choices.size(); ++i)
+    {
+        if (definition->choices[i].choice_id == choice_id)
+        {
+            valid = true;
+            break;
+        }
+    }
+    if (!valid)
+        return false;
+    Pair<int, int> *choice_entry = this->_quest_choices.find(quest_id);
+    if (choice_entry == ft_nullptr)
+        this->_quest_choices.insert(quest_id, choice_id);
+    else
+        choice_entry->value = choice_id;
+    progress_entry->value.status = QUEST_STATUS_COMPLETED;
+    progress_entry->value.time_remaining = 0.0;
+    this->update_availability();
+    this->activate_next();
+    return true;
+}
+
+int QuestManager::get_choice(int quest_id) const
+{
+    const Pair<int, int> *entry = this->_quest_choices.find(quest_id);
+    if (entry == ft_nullptr)
+        return QUEST_CHOICE_NONE;
+    return entry->value;
+}

--- a/src/quests.hpp
+++ b/src/quests.hpp
@@ -1,0 +1,125 @@
+#ifndef QUESTS_HPP
+#define QUESTS_HPP
+
+#include "planets.hpp"
+#include "research.hpp"
+#include "../libft/Libft/libft.hpp"
+#include "../libft/Template/map.hpp"
+#include "../libft/Template/vector.hpp"
+#include "../libft/Template/pair.hpp"
+#include "../libft/Template/shared_ptr.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+enum e_quest_id
+{
+    QUEST_INITIAL_SKIRMISHES = 1,
+    QUEST_DEFENSE_OF_TERRA,
+    QUEST_INVESTIGATE_RAIDERS,
+    QUEST_CLIMACTIC_BATTLE,
+    QUEST_CRITICAL_DECISION,
+    QUEST_ORDER_UPRISING,
+    QUEST_REBELLION_FLEET
+};
+
+enum e_quest_status
+{
+    QUEST_STATUS_LOCKED = 0,
+    QUEST_STATUS_AVAILABLE,
+    QUEST_STATUS_ACTIVE,
+    QUEST_STATUS_AWAITING_CHOICE,
+    QUEST_STATUS_COMPLETED,
+    QUEST_STATUS_FAILED
+};
+
+enum e_quest_objective_type
+{
+    QUEST_OBJECTIVE_RESOURCE_TOTAL = 1,
+    QUEST_OBJECTIVE_RESEARCH_COMPLETED,
+    QUEST_OBJECTIVE_FLEET_COUNT,
+    QUEST_OBJECTIVE_TOTAL_SHIP_HP
+};
+
+enum e_quest_choice_value
+{
+    QUEST_CHOICE_NONE = 0,
+    QUEST_CHOICE_EXECUTE_BLACKTHORNE = 1,
+    QUEST_CHOICE_SPARE_BLACKTHORNE = 2
+};
+
+struct ft_quest_objective
+{
+    int type;
+    int target_id;
+    int amount;
+    ft_quest_objective() : type(0), target_id(0), amount(0) {}
+};
+
+struct ft_quest_choice_definition
+{
+    int choice_id;
+    ft_string description;
+    ft_quest_choice_definition() : choice_id(0), description() {}
+};
+
+struct ft_quest_definition
+{
+    int                                 id;
+    ft_string                           name;
+    ft_string                           description;
+    double                              time_limit;
+    ft_vector<ft_quest_objective>       objectives;
+    ft_vector<int>                      prerequisites;
+    bool                                requires_choice;
+    ft_vector<ft_quest_choice_definition> choices;
+    int                                 required_choice_quest;
+    int                                 required_choice_value;
+    ft_quest_definition()
+        : id(0), name(), description(), time_limit(0.0), objectives(), prerequisites(),
+          requires_choice(false), choices(), required_choice_quest(0), required_choice_value(0)
+    {}
+};
+
+struct ft_quest_progress
+{
+    int     status;
+    double  time_remaining;
+    ft_quest_progress() : status(QUEST_STATUS_LOCKED), time_remaining(0.0) {}
+};
+
+struct ft_quest_context
+{
+    ft_map<int, int> resource_totals;
+    ft_map<int, int> research_status;
+    int total_ship_count;
+    int total_ship_hp;
+    ft_quest_context() : resource_totals(), research_status(), total_ship_count(0), total_ship_hp(0) {}
+};
+
+class QuestManager
+{
+private:
+    ft_map<int, ft_sharedptr<ft_quest_definition> > _definitions;
+    ft_map<int, ft_quest_progress>                  _progress;
+    ft_map<int, int>                                _quest_choices;
+
+    void register_quest(const ft_sharedptr<ft_quest_definition> &definition);
+    void update_availability();
+    void activate_next();
+    bool are_objectives_met(const ft_quest_definition &definition, const ft_quest_context &context) const;
+
+public:
+    QuestManager();
+
+    void update(double seconds, const ft_quest_context &context,
+                ft_vector<int> &completed, ft_vector<int> &failed,
+                ft_vector<int> &awaiting_choice);
+
+    int get_active_quest_id() const;
+    int get_status(int quest_id) const;
+    double get_time_remaining(int quest_id) const;
+    const ft_quest_definition *get_definition(int quest_id) const;
+    bool make_choice(int quest_id, int choice_id);
+    int get_choice(int quest_id) const;
+};
+
+#endif

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -1,0 +1,215 @@
+#include "research.hpp"
+
+ResearchManager::ResearchManager()
+{
+    ft_sharedptr<ft_research_definition> mars(new ft_research_definition());
+    mars->id = RESEARCH_UNLOCK_MARS;
+    mars->name = ft_string("Unlock Mars");
+    mars->duration = 30.0;
+    mars->prerequisites.clear();
+    mars->costs.clear();
+    mars->unlock_planets.clear();
+    Pair<int, int> cost;
+    cost.key = ORE_IRON;
+    cost.value = 18;
+    mars->costs.push_back(cost);
+    cost.key = ORE_COPPER;
+    cost.value = 12;
+    mars->costs.push_back(cost);
+    cost.key = ORE_COAL;
+    cost.value = 6;
+    mars->costs.push_back(cost);
+    mars->unlock_planets.push_back(PLANET_MARS);
+    this->register_research(mars);
+
+    ft_sharedptr<ft_research_definition> zalthor(new ft_research_definition());
+    zalthor->id = RESEARCH_UNLOCK_ZALTHOR;
+    zalthor->name = ft_string("Unlock Zalthor");
+    zalthor->duration = 40.0;
+    zalthor->prerequisites.clear();
+    zalthor->prerequisites.push_back(RESEARCH_UNLOCK_MARS);
+    zalthor->costs.clear();
+    cost.key = ORE_MITHRIL;
+    cost.value = 8;
+    zalthor->costs.push_back(cost);
+    cost.key = ORE_COAL;
+    cost.value = 6;
+    zalthor->costs.push_back(cost);
+    zalthor->unlock_planets.clear();
+    zalthor->unlock_planets.push_back(PLANET_ZALTHOR);
+    this->register_research(zalthor);
+
+    ft_sharedptr<ft_research_definition> vulcan(new ft_research_definition());
+    vulcan->id = RESEARCH_UNLOCK_VULCAN;
+    vulcan->name = ft_string("Unlock Vulcan");
+    vulcan->duration = 55.0;
+    vulcan->prerequisites.clear();
+    vulcan->prerequisites.push_back(RESEARCH_UNLOCK_ZALTHOR);
+    vulcan->costs.clear();
+    cost.key = ORE_GOLD;
+    cost.value = 6;
+    vulcan->costs.push_back(cost);
+    cost.key = ORE_MITHRIL;
+    cost.value = 8;
+    vulcan->costs.push_back(cost);
+    vulcan->unlock_planets.clear();
+    vulcan->unlock_planets.push_back(PLANET_VULCAN);
+    this->register_research(vulcan);
+
+    ft_sharedptr<ft_research_definition> noctaris(new ft_research_definition());
+    noctaris->id = RESEARCH_UNLOCK_NOCTARIS;
+    noctaris->name = ft_string("Unlock Noctaris Prime");
+    noctaris->duration = 60.0;
+    noctaris->prerequisites.clear();
+    noctaris->prerequisites.push_back(RESEARCH_UNLOCK_VULCAN);
+    noctaris->costs.clear();
+    cost.key = ORE_TITANIUM;
+    cost.value = 5;
+    noctaris->costs.push_back(cost);
+    cost.key = ORE_SILVER;
+    cost.value = 6;
+    noctaris->costs.push_back(cost);
+    cost.key = ORE_TIN;
+    cost.value = 6;
+    noctaris->costs.push_back(cost);
+    noctaris->unlock_planets.clear();
+    noctaris->unlock_planets.push_back(PLANET_NOCTARIS_PRIME);
+    this->register_research(noctaris);
+
+    this->update_availability();
+}
+
+void ResearchManager::register_research(const ft_sharedptr<ft_research_definition> &definition)
+{
+    this->_definitions.insert(definition->id, definition);
+    ft_research_progress progress;
+    if (definition->prerequisites.size() == 0)
+        progress.status = RESEARCH_STATUS_AVAILABLE;
+    else
+        progress.status = RESEARCH_STATUS_LOCKED;
+    progress.remaining_time = 0.0;
+    this->_progress.insert(definition->id, progress);
+}
+
+void ResearchManager::update_availability()
+{
+    size_t count = this->_progress.size();
+    Pair<int, ft_research_progress> *entries = this->_progress.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_research_progress &progress = entries[i].value;
+        if (progress.status != RESEARCH_STATUS_LOCKED)
+            continue;
+        const ft_research_definition *definition = this->get_definition(entries[i].key);
+        if (definition == ft_nullptr)
+            continue;
+        bool ready = true;
+        for (size_t j = 0; j < definition->prerequisites.size(); ++j)
+        {
+            int prereq = definition->prerequisites[j];
+            const Pair<int, ft_research_progress> *entry = this->_progress.find(prereq);
+            if (entry == ft_nullptr || entry->value.status != RESEARCH_STATUS_COMPLETED)
+            {
+                ready = false;
+                break;
+            }
+        }
+        if (ready)
+            progress.status = RESEARCH_STATUS_AVAILABLE;
+    }
+}
+
+void ResearchManager::tick(double seconds, ft_vector<int> &completed)
+{
+    size_t count = this->_progress.size();
+    Pair<int, ft_research_progress> *entries = this->_progress.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_research_progress &progress = entries[i].value;
+        if (progress.status != RESEARCH_STATUS_IN_PROGRESS)
+            continue;
+        if (progress.remaining_time > seconds)
+            progress.remaining_time -= seconds;
+        else
+        {
+            progress.remaining_time = 0.0;
+            progress.status = RESEARCH_STATUS_COMPLETED;
+            completed.push_back(entries[i].key);
+        }
+    }
+    if (completed.size() > 0)
+        this->update_availability();
+}
+
+bool ResearchManager::can_start(int research_id) const
+{
+    const Pair<int, ft_research_progress> *entry = this->_progress.find(research_id);
+    if (entry == ft_nullptr)
+        return false;
+    return entry->value.status == RESEARCH_STATUS_AVAILABLE;
+}
+
+bool ResearchManager::start(int research_id)
+{
+    Pair<int, ft_research_progress> *entry = this->_progress.find(research_id);
+    if (entry == ft_nullptr)
+        return false;
+    if (entry->value.status != RESEARCH_STATUS_AVAILABLE)
+        return false;
+    const ft_research_definition *definition = this->get_definition(research_id);
+    if (definition == ft_nullptr)
+        return false;
+    entry->value.status = RESEARCH_STATUS_IN_PROGRESS;
+    entry->value.remaining_time = definition->duration;
+    if (entry->value.remaining_time <= 0.0)
+    {
+        entry->value.remaining_time = 0.0;
+        entry->value.status = RESEARCH_STATUS_COMPLETED;
+        this->update_availability();
+    }
+    return true;
+}
+
+bool ResearchManager::is_completed(int research_id) const
+{
+    const Pair<int, ft_research_progress> *entry = this->_progress.find(research_id);
+    if (entry == ft_nullptr)
+        return false;
+    return entry->value.status == RESEARCH_STATUS_COMPLETED;
+}
+
+int ResearchManager::get_status(int research_id) const
+{
+    const Pair<int, ft_research_progress> *entry = this->_progress.find(research_id);
+    if (entry == ft_nullptr)
+        return RESEARCH_STATUS_LOCKED;
+    return entry->value.status;
+}
+
+double ResearchManager::get_remaining_time(int research_id) const
+{
+    const Pair<int, ft_research_progress> *entry = this->_progress.find(research_id);
+    if (entry == ft_nullptr)
+        return 0.0;
+    return entry->value.remaining_time;
+}
+
+const ft_research_definition *ResearchManager::get_definition(int research_id) const
+{
+    const Pair<int, ft_sharedptr<ft_research_definition> > *entry = this->_definitions.find(research_id);
+    if (entry == ft_nullptr)
+        return ft_nullptr;
+    return entry->value.get();
+}
+
+void ResearchManager::mark_completed(int research_id)
+{
+    Pair<int, ft_research_progress> *entry = this->_progress.find(research_id);
+    if (entry == ft_nullptr)
+        return ;
+    entry->value.status = RESEARCH_STATUS_COMPLETED;
+    entry->value.remaining_time = 0.0;
+    this->update_availability();
+}

--- a/src/research.hpp
+++ b/src/research.hpp
@@ -1,0 +1,68 @@
+#ifndef RESEARCH_HPP
+#define RESEARCH_HPP
+
+#include "planets.hpp"
+#include "../libft/Libft/libft.hpp"
+#include "../libft/Template/map.hpp"
+#include "../libft/Template/vector.hpp"
+#include "../libft/Template/pair.hpp"
+#include "../libft/Template/shared_ptr.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+enum e_research_id
+{
+    RESEARCH_UNLOCK_MARS = 1,
+    RESEARCH_UNLOCK_ZALTHOR,
+    RESEARCH_UNLOCK_VULCAN,
+    RESEARCH_UNLOCK_NOCTARIS
+};
+
+enum e_research_status
+{
+    RESEARCH_STATUS_LOCKED = 0,
+    RESEARCH_STATUS_AVAILABLE,
+    RESEARCH_STATUS_IN_PROGRESS,
+    RESEARCH_STATUS_COMPLETED
+};
+
+struct ft_research_definition
+{
+    int                         id;
+    ft_string                   name;
+    double                      duration;
+    ft_vector<int>              prerequisites;
+    ft_vector<Pair<int, int> >  costs;
+    ft_vector<int>              unlock_planets;
+};
+
+struct ft_research_progress
+{
+    int     status;
+    double  remaining_time;
+    ft_research_progress() : status(RESEARCH_STATUS_LOCKED), remaining_time(0.0) {}
+};
+
+class ResearchManager
+{
+private:
+    ft_map<int, ft_sharedptr<ft_research_definition> > _definitions;
+    ft_map<int, ft_research_progress>   _progress;
+
+    void register_research(const ft_sharedptr<ft_research_definition> &definition);
+    void update_availability();
+
+public:
+    ResearchManager();
+
+    void tick(double seconds, ft_vector<int> &completed);
+
+    bool can_start(int research_id) const;
+    bool start(int research_id);
+    bool is_completed(int research_id) const;
+    int get_status(int research_id) const;
+    double get_remaining_time(int research_id) const;
+    const ft_research_definition *get_definition(int research_id) const;
+    void mark_completed(int research_id);
+};
+
+#endif

--- a/tests/game_test.cpp
+++ b/tests/game_test.cpp
@@ -7,6 +7,9 @@
 #include "../libft/Template/pair.hpp"
 #include "game.hpp"
 #include "fleets.hpp"
+#include "research.hpp"
+#include "quests.hpp"
+#include "buildings.hpp"
 
 static void run_server()
 {
@@ -31,6 +34,27 @@ int main()
     FT_ASSERT_EQ(0, ft_strcmp(resp + response.size() - 4, "test"));
 
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    FT_ASSERT(game.is_planet_unlocked(PLANET_TERRA));
+    FT_ASSERT(!game.is_planet_unlocked(PLANET_MARS));
+    FT_ASSERT(!game.is_planet_unlocked(PLANET_ZALTHOR));
+    FT_ASSERT(!game.is_planet_unlocked(PLANET_VULCAN));
+    FT_ASSERT(!game.is_planet_unlocked(PLANET_NOCTARIS_PRIME));
+
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_UNLOCK_MARS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_UNLOCK_ZALTHOR));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_UNLOCK_VULCAN));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_UNLOCK_NOCTARIS));
+    FT_ASSERT(!game.can_start_research(RESEARCH_UNLOCK_MARS));
+    FT_ASSERT(!game.can_start_research(RESEARCH_UNLOCK_ZALTHOR));
+
+    FT_ASSERT_EQ(QUEST_INITIAL_SKIRMISHES, game.get_active_quest());
+    FT_ASSERT_EQ(QUEST_STATUS_ACTIVE, game.get_quest_status(QUEST_INITIAL_SKIRMISHES));
+    FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_DEFENSE_OF_TERRA));
+    FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_INVESTIGATE_RAIDERS));
+    FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_CLIMACTIC_BATTLE));
+    FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_CRITICAL_DECISION));
+    FT_ASSERT_EQ(QUEST_CHOICE_NONE, game.get_quest_choice(QUEST_CRITICAL_DECISION));
+
     int ore = game.add_ore(PLANET_TERRA, ORE_COPPER, 5);
     FT_ASSERT_EQ(5, ore);
     ore = game.sub_ore(PLANET_TERRA, ORE_COPPER, 2);
@@ -42,11 +66,113 @@ int main()
     FT_ASSERT(rate > 0.49 && rate < 0.51);
     const ft_vector<Pair<int, double> > &terra_res = game.get_planet_resources(PLANET_TERRA);
     FT_ASSERT_EQ(3, static_cast<int>(terra_res.size()));
-    double mithril_rate = game.get_rate(PLANET_MARS, ORE_MITHRIL);
-    FT_ASSERT(mithril_rate > 0.049 && mithril_rate < 0.051);
+    FT_ASSERT(game.get_rate(PLANET_MARS, ORE_MITHRIL) < 0.0001);
 
     game.produce(10.0);
     FT_ASSERT_EQ(12, game.get_ore(PLANET_TERRA, ORE_IRON));
+    FT_ASSERT(!game.start_research(RESEARCH_UNLOCK_MARS));
+
+    game.set_ore(PLANET_TERRA, ORE_IRON, 40);
+    game.set_ore(PLANET_TERRA, ORE_COPPER, 30);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 12);
+    game.tick(0.0);
+    FT_ASSERT_EQ(QUEST_STATUS_COMPLETED, game.get_quest_status(QUEST_INITIAL_SKIRMISHES));
+    FT_ASSERT_EQ(QUEST_DEFENSE_OF_TERRA, game.get_active_quest());
+    FT_ASSERT_EQ(QUEST_STATUS_ACTIVE, game.get_quest_status(QUEST_DEFENSE_OF_TERRA));
+    FT_ASSERT(game.can_start_research(RESEARCH_UNLOCK_MARS));
+    FT_ASSERT(game.start_research(RESEARCH_UNLOCK_MARS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_IN_PROGRESS, game.get_research_status(RESEARCH_UNLOCK_MARS));
+    double remaining = game.get_research_time_remaining(RESEARCH_UNLOCK_MARS);
+    FT_ASSERT(remaining > 29.9 && remaining < 30.1);
+    game.tick(10.0);
+    double after = game.get_research_time_remaining(RESEARCH_UNLOCK_MARS);
+    FT_ASSERT(after > 19.9 && after < 20.1);
+    game.tick(25.0);
+    FT_ASSERT(game.is_planet_unlocked(PLANET_MARS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_UNLOCK_MARS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_UNLOCK_ZALTHOR));
+    double mithril_rate = game.get_rate(PLANET_MARS, ORE_MITHRIL);
+    FT_ASSERT(mithril_rate > 0.049 && mithril_rate < 0.051);
+
+    game.set_ore(PLANET_TERRA, ORE_COAL, 3);
+    game.set_ore(PLANET_MARS, ORE_COAL, 4);
+    game.set_ore(PLANET_MARS, ORE_MITHRIL, 9);
+    int coal_before = game.get_ore(PLANET_TERRA, ORE_COAL) + game.get_ore(PLANET_MARS, ORE_COAL);
+    int mithril_before = game.get_ore(PLANET_TERRA, ORE_MITHRIL) + game.get_ore(PLANET_MARS, ORE_MITHRIL);
+    FT_ASSERT(game.can_start_research(RESEARCH_UNLOCK_ZALTHOR));
+    FT_ASSERT(game.start_research(RESEARCH_UNLOCK_ZALTHOR));
+    FT_ASSERT_EQ(RESEARCH_STATUS_IN_PROGRESS, game.get_research_status(RESEARCH_UNLOCK_ZALTHOR));
+    int coal_after = game.get_ore(PLANET_TERRA, ORE_COAL) + game.get_ore(PLANET_MARS, ORE_COAL);
+    int mithril_after = game.get_ore(PLANET_TERRA, ORE_MITHRIL) + game.get_ore(PLANET_MARS, ORE_MITHRIL);
+    FT_ASSERT_EQ(coal_before - 6, coal_after);
+    FT_ASSERT_EQ(mithril_before - 8, mithril_after);
+    game.tick(20.0);
+    double z_remaining = game.get_research_time_remaining(RESEARCH_UNLOCK_ZALTHOR);
+    FT_ASSERT(z_remaining > 19.9 && z_remaining < 20.1);
+    game.tick(25.0);
+    FT_ASSERT(game.is_planet_unlocked(PLANET_ZALTHOR));
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_UNLOCK_ZALTHOR));
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_UNLOCK_VULCAN));
+    game.tick(0.0);
+    FT_ASSERT_EQ(QUEST_STATUS_COMPLETED, game.get_quest_status(QUEST_INVESTIGATE_RAIDERS));
+    FT_ASSERT_EQ(QUEST_CLIMACTIC_BATTLE, game.get_active_quest());
+    FT_ASSERT_EQ(QUEST_STATUS_ACTIVE, game.get_quest_status(QUEST_CLIMACTIC_BATTLE));
+
+    game.set_ore(PLANET_ZALTHOR, ORE_GOLD, 7);
+    game.set_ore(PLANET_MARS, ORE_MITHRIL, 12);
+    int gold_before = game.get_ore(PLANET_ZALTHOR, ORE_GOLD);
+    int mithril_before_v = game.get_ore(PLANET_MARS, ORE_MITHRIL);
+    FT_ASSERT(game.can_start_research(RESEARCH_UNLOCK_VULCAN));
+    FT_ASSERT(game.start_research(RESEARCH_UNLOCK_VULCAN));
+    FT_ASSERT_EQ(RESEARCH_STATUS_IN_PROGRESS, game.get_research_status(RESEARCH_UNLOCK_VULCAN));
+    int gold_after = game.get_ore(PLANET_ZALTHOR, ORE_GOLD);
+    int mithril_after_v = game.get_ore(PLANET_MARS, ORE_MITHRIL);
+    FT_ASSERT_EQ(gold_before - 6, gold_after);
+    FT_ASSERT_EQ(mithril_before_v - 8, mithril_after_v);
+    game.tick(30.0);
+    double v_remaining = game.get_research_time_remaining(RESEARCH_UNLOCK_VULCAN);
+    FT_ASSERT(v_remaining > 24.9 && v_remaining < 25.1);
+    game.tick(30.0);
+    FT_ASSERT(game.is_planet_unlocked(PLANET_VULCAN));
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_UNLOCK_VULCAN));
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_UNLOCK_NOCTARIS));
+    game.tick(0.0);
+    FT_ASSERT_EQ(QUEST_STATUS_COMPLETED, game.get_quest_status(QUEST_CLIMACTIC_BATTLE));
+    FT_ASSERT_EQ(QUEST_CRITICAL_DECISION, game.get_active_quest());
+    FT_ASSERT_EQ(QUEST_STATUS_AWAITING_CHOICE, game.get_quest_status(QUEST_CRITICAL_DECISION));
+    FT_ASSERT(game.resolve_quest_choice(QUEST_CRITICAL_DECISION, QUEST_CHOICE_SPARE_BLACKTHORNE));
+    FT_ASSERT_EQ(QUEST_CHOICE_SPARE_BLACKTHORNE, game.get_quest_choice(QUEST_CRITICAL_DECISION));
+    FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_ORDER_UPRISING));
+    FT_ASSERT_EQ(QUEST_REBELLION_FLEET, game.get_active_quest());
+    FT_ASSERT_EQ(QUEST_STATUS_ACTIVE, game.get_quest_status(QUEST_REBELLION_FLEET));
+
+    game.set_ore(PLANET_VULCAN, ORE_TIN, 9);
+    game.set_ore(PLANET_VULCAN, ORE_SILVER, 8);
+    game.set_ore(PLANET_VULCAN, ORE_TITANIUM, 7);
+    int tin_before = game.get_ore(PLANET_VULCAN, ORE_TIN);
+    int silver_before = game.get_ore(PLANET_VULCAN, ORE_SILVER);
+    int titanium_before = game.get_ore(PLANET_VULCAN, ORE_TITANIUM);
+    FT_ASSERT(game.can_start_research(RESEARCH_UNLOCK_NOCTARIS));
+    FT_ASSERT(game.start_research(RESEARCH_UNLOCK_NOCTARIS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_IN_PROGRESS, game.get_research_status(RESEARCH_UNLOCK_NOCTARIS));
+    int tin_after = game.get_ore(PLANET_VULCAN, ORE_TIN);
+    int silver_after = game.get_ore(PLANET_VULCAN, ORE_SILVER);
+    int titanium_after = game.get_ore(PLANET_VULCAN, ORE_TITANIUM);
+    FT_ASSERT_EQ(tin_before - 6, tin_after);
+    FT_ASSERT_EQ(silver_before - 6, silver_after);
+    FT_ASSERT_EQ(titanium_before - 5, titanium_after);
+    game.tick(30.0);
+    double n_remaining = game.get_research_time_remaining(RESEARCH_UNLOCK_NOCTARIS);
+    FT_ASSERT(n_remaining > 29.9 && n_remaining < 30.1);
+    game.tick(35.0);
+    FT_ASSERT(game.is_planet_unlocked(PLANET_NOCTARIS_PRIME));
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_UNLOCK_NOCTARIS));
+    game.set_ore(PLANET_NOCTARIS_PRIME, ORE_OBSIDIAN, 6);
+    game.tick(0.0);
+    FT_ASSERT_EQ(QUEST_CHOICE_SPARE_BLACKTHORNE, game.get_quest_choice(QUEST_CRITICAL_DECISION));
+    FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_ORDER_UPRISING));
+    FT_ASSERT_EQ(QUEST_STATUS_COMPLETED, game.get_quest_status(QUEST_REBELLION_FLEET));
+    FT_ASSERT_EQ(0, game.get_active_quest());
 
     game.set_ore(PLANET_TERRA, ORE_COPPER, 10);
     game.set_ore(PLANET_MARS, ORE_COPPER, 0);
@@ -81,6 +207,10 @@ int main()
     game.set_ship_hp(1, ship_b, 80);
     FT_ASSERT_EQ(80, game.get_ship_hp(1, ship_b));
     FT_ASSERT_EQ(90, game.get_ship_hp(1, ship_a));
+    game.tick(0.0);
+    FT_ASSERT_EQ(QUEST_STATUS_COMPLETED, game.get_quest_status(QUEST_DEFENSE_OF_TERRA));
+    FT_ASSERT_EQ(QUEST_INVESTIGATE_RAIDERS, game.get_active_quest());
+    FT_ASSERT_EQ(QUEST_STATUS_ACTIVE, game.get_quest_status(QUEST_INVESTIGATE_RAIDERS));
     game.set_fleet_location_planet(1, PLANET_TERRA);
     ft_location loc1 = game.get_fleet_location(1);
     FT_ASSERT_EQ(LOCATION_PLANET, loc1.type);
@@ -90,6 +220,8 @@ int main()
     int ship_c = game.create_ship(2, SHIP_SHIELD);
     FT_ASSERT(ship_c != ship_a);
     FT_ASSERT(ship_c != ship_b);
+    game.set_ship_hp(2, ship_c, 120);
+    FT_ASSERT_EQ(120, game.get_ship_hp(2, ship_c));
     game.set_fleet_location_travel(2, PLANET_MARS, PLANET_VULCAN, 5.0);
     ft_location loc2 = game.get_fleet_location(2);
     FT_ASSERT_EQ(LOCATION_TRAVEL, loc2.type);
@@ -153,6 +285,122 @@ int main()
     game.remove_fleet(5, -1, PLANET_MARS);
     FT_ASSERT_EQ(37, game.get_planet_fleet_ship_hp(PLANET_MARS, ship_e));
     FT_ASSERT_EQ(18, game.get_planet_fleet_ship_hp(PLANET_MARS, ship_f));
+
+    game.create_fleet(6);
+    int ship_g = game.create_ship(6, SHIP_CAPITAL);
+    FT_ASSERT(ship_g != 0);
+    game.set_ship_hp(6, ship_g, 150);
+    game.set_ship_shield(6, ship_g, 70);
+    game.set_ship_armor(6, ship_g, 40);
+    game.set_ship_shield(2, ship_a, 45);
+    game.set_ship_shield(2, ship_c, 30);
+
+    game.set_ore(PLANET_TERRA, ORE_IRON, 0);
+    game.set_ore(PLANET_TERRA, ORE_COPPER, 0);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 0);
+    size_t lore_before = game.get_lore_log().size();
+    FT_ASSERT(game.start_raider_assault(PLANET_TERRA, 1.0));
+    FT_ASSERT(game.is_assault_active(PLANET_TERRA));
+    double initial_raider_shield = game.get_assault_raider_shield(PLANET_TERRA);
+    FT_ASSERT(initial_raider_shield > 79.9 && initial_raider_shield < 80.1);
+    FT_ASSERT(game.assign_fleet_to_assault(PLANET_TERRA, 2));
+    FT_ASSERT(game.assign_fleet_to_assault(PLANET_TERRA, 6));
+    FT_ASSERT(!game.assign_fleet_to_assault(PLANET_TERRA, 99));
+    FT_ASSERT(game.set_assault_support(PLANET_TERRA, true, true, true));
+    game.tick(2.0);
+    double shield_after_tick = game.get_assault_raider_shield(PLANET_TERRA);
+    FT_ASSERT(shield_after_tick < initial_raider_shield);
+    FT_ASSERT(game.get_ship_hp(2, ship_a) > 0);
+    for (int step = 0; step < 12 && game.is_assault_active(PLANET_TERRA); ++step)
+        game.tick(2.0);
+    FT_ASSERT(!game.is_assault_active(PLANET_TERRA));
+    double final_raider_hull = game.get_assault_raider_hull(PLANET_TERRA);
+    FT_ASSERT(final_raider_hull >= -0.1 && final_raider_hull < 0.1);
+    size_t lore_after = game.get_lore_log().size();
+    FT_ASSERT(lore_after >= lore_before + 2);
+    int terra_iron = game.get_ore(PLANET_TERRA, ORE_IRON);
+    FT_ASSERT(terra_iron >= 9);
+
+    game.set_ore(PLANET_MARS, ORE_IRON, 4);
+    size_t lore_mid = game.get_lore_log().size();
+    FT_ASSERT(game.start_raider_assault(PLANET_MARS, 0.8));
+    FT_ASSERT(game.is_assault_active(PLANET_MARS));
+    game.tick(1.0);
+    FT_ASSERT(!game.is_assault_active(PLANET_MARS));
+    FT_ASSERT(game.get_assault_raider_shield(PLANET_MARS) < 0.01);
+    int mars_iron = game.get_ore(PLANET_MARS, ORE_IRON);
+    FT_ASSERT(mars_iron <= 2);
+    size_t lore_end = game.get_lore_log().size();
+    FT_ASSERT(lore_end >= lore_mid + 1);
+    FT_ASSERT(!game.set_assault_support(PLANET_MARS, true, false, false));
+
+    int terra_mine_instance = game.get_building_instance(PLANET_TERRA, 0, 0);
+    FT_ASSERT(terra_mine_instance != 0);
+    FT_ASSERT(!game.remove_building(PLANET_TERRA, terra_mine_instance));
+    FT_ASSERT_EQ(16, game.get_planet_plot_capacity(PLANET_TERRA));
+    FT_ASSERT_EQ(1, game.get_planet_plot_usage(PLANET_TERRA));
+    FT_ASSERT_EQ(1, game.get_building_count(PLANET_TERRA, BUILDING_MINE_CORE));
+    FT_ASSERT(!game.can_place_building(PLANET_TERRA, BUILDING_SMELTER, 0, 0));
+
+    game.set_ore(PLANET_TERRA, ORE_IRON, 200);
+    game.set_ore(PLANET_TERRA, ORE_COPPER, 200);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 200);
+    game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 0);
+    game.set_ore(PLANET_TERRA, ITEM_COPPER_BAR, 0);
+
+    FT_ASSERT(game.can_place_building(PLANET_TERRA, BUILDING_POWER_GENERATOR, 2, 0));
+    int terra_generator = game.place_building(PLANET_TERRA, BUILDING_POWER_GENERATOR, 2, 0);
+    FT_ASSERT(terra_generator != 0);
+    FT_ASSERT(game.place_building(PLANET_TERRA, BUILDING_CONVEYOR, 1, 0) != 0);
+    FT_ASSERT(game.place_building(PLANET_TERRA, BUILDING_TRANSFER_NODE, 1, 1) != 0);
+    FT_ASSERT(game.place_building(PLANET_TERRA, BUILDING_SMELTER, 0, 2) != 0);
+    FT_ASSERT(game.place_building(PLANET_TERRA, BUILDING_PROCESSOR, 2, 2) != 0);
+
+    FT_ASSERT_EQ(4, game.get_planet_logistic_capacity(PLANET_TERRA));
+    double terra_energy_gen = game.get_planet_energy_generation(PLANET_TERRA);
+    FT_ASSERT(terra_energy_gen > 5.9 && terra_energy_gen < 6.1);
+    game.tick(10.0);
+    FT_ASSERT(game.get_planet_logistic_usage(PLANET_TERRA) >= 2);
+    double terra_energy_use = game.get_planet_energy_consumption(PLANET_TERRA);
+    FT_ASSERT(terra_energy_use > 4.49 && terra_energy_use < 4.51);
+    FT_ASSERT(game.get_ore(PLANET_TERRA, ITEM_IRON_BAR) >= 4);
+    FT_ASSERT(game.get_ore(PLANET_TERRA, ITEM_COPPER_BAR) >= 2);
+
+    int conveyor_instance = game.get_building_instance(PLANET_TERRA, 1, 0);
+    FT_ASSERT(conveyor_instance != 0);
+    FT_ASSERT(game.remove_building(PLANET_TERRA, conveyor_instance));
+    FT_ASSERT_EQ(3, game.get_planet_logistic_capacity(PLANET_TERRA));
+
+    game.set_ore(PLANET_VULCAN, ORE_IRON, 150);
+    game.set_ore(PLANET_VULCAN, ORE_COPPER, 150);
+    game.set_ore(PLANET_VULCAN, ORE_COAL, 150);
+    game.set_ore(PLANET_VULCAN, ITEM_IRON_BAR, 0);
+    game.set_ore(PLANET_VULCAN, ITEM_COPPER_BAR, 0);
+    game.set_ore(PLANET_VULCAN, ITEM_ENGINE_PART, 0);
+
+    FT_ASSERT(game.place_building(PLANET_VULCAN, BUILDING_POWER_GENERATOR, 2, 0) != 0);
+    FT_ASSERT(game.place_building(PLANET_VULCAN, BUILDING_CONVEYOR, 1, 0) != 0);
+    FT_ASSERT(game.place_building(PLANET_VULCAN, BUILDING_TRANSFER_NODE, 1, 1) != 0);
+    FT_ASSERT(game.place_building(PLANET_VULCAN, BUILDING_CRAFTING_BAY, 0, 2) != 0);
+    FT_ASSERT_EQ(4, game.get_planet_logistic_capacity(PLANET_VULCAN));
+
+    int moved_iron = game.transfer_ore(PLANET_TERRA, PLANET_VULCAN, ITEM_IRON_BAR, 4);
+    int moved_copper = game.transfer_ore(PLANET_TERRA, PLANET_VULCAN, ITEM_COPPER_BAR, 2);
+    FT_ASSERT(moved_iron >= 4);
+    FT_ASSERT(moved_copper >= 2);
+
+    double vulcan_energy = game.get_planet_energy_generation(PLANET_VULCAN);
+    FT_ASSERT(vulcan_energy > 5.9 && vulcan_energy < 6.1);
+    game.tick(16.0);
+    FT_ASSERT(game.get_planet_logistic_usage(PLANET_VULCAN) >= 2);
+    double vulcan_use = game.get_planet_energy_consumption(PLANET_VULCAN);
+    FT_ASSERT(vulcan_use > 3.9 && vulcan_use < 4.1);
+    FT_ASSERT(game.get_ore(PLANET_VULCAN, ITEM_ENGINE_PART) >= 2);
+    FT_ASSERT(game.get_planet_logistic_usage(PLANET_TERRA) >= 2);
+    double terra_use_after = game.get_planet_energy_consumption(PLANET_TERRA);
+    FT_ASSERT(terra_use_after > 4.49 && terra_use_after < 4.51);
+    double terra_mine_bonus = game.get_planet_mine_multiplier(PLANET_TERRA);
+    FT_ASSERT(terra_mine_bonus > 0.99 && terra_mine_bonus < 1.01);
 
     server_thread.join();
     return 0;


### PR DESCRIPTION
## Summary
- implement a building manager with energy, logistic, and mining bonuses and integrate it into the game loop
- expose building management APIs on the Game class and ensure planets support processed resource slots
- extend the regression test to exercise building placement, production, and crafting of engine parts

## Testing
- make test *(fails: libft dependency missing in repository snapshot)*
- ./test *(not built because make test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c86ffe63948331a35293133f846775