### PR TITLE
Add solar panel tech and crafting energy research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+objs/
+objs_debug/
+galactic_miner
+galactic_miner_debug
+test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
 # AGENTS
 
 Any game logic or tests in this repository must prefer modules provided by `libft` over the C++ standard library whenever a similar feature exists. Use libft types and functions such as `ft_string`, `ft_thread`, `ft_this_thread_*`, `ft_to_string`, `ft_strcmp`, and time helpers instead of their standard library counterparts.
+
+Keep `test_failures.log` under version control so that failure histories with timestamps remain available for debugging. When updating the file, remove entries for issues that are no longer present so the log reflects only outstanding problems.

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -19,6 +19,7 @@ enum e_building_id
     BUILDING_CONVEYOR,
     BUILDING_TRANSFER_NODE,
     BUILDING_POWER_GENERATOR,
+    BUILDING_SOLAR_ARRAY,
     BUILDING_UPGRADE_STATION
 };
 
@@ -59,6 +60,7 @@ struct ft_planet_build_state
     int                         width;
     int                         height;
     int                         base_logistic;
+    int                         research_logistic_bonus;
     int                         used_plots;
     int                         logistic_capacity;
     int                         logistic_usage;
@@ -79,6 +81,8 @@ class BuildingManager
 private:
     ft_map<int, ft_sharedptr<ft_building_definition> > _definitions;
     ft_map<int, ft_planet_build_state>                  _planets;
+    bool                                               _solar_panels_unlocked;
+    double                                             _crafting_energy_multiplier;
 
     void register_definition(const ft_sharedptr<ft_building_definition> &definition);
     const ft_building_definition *get_definition(int building_id) const;
@@ -99,6 +103,9 @@ public:
     BuildingManager();
 
     void initialize_planet(Game &game, int planet_id);
+    void add_planet_logistic_bonus(int planet_id, int amount);
+    void unlock_solar_panels();
+    void set_crafting_energy_multiplier(double multiplier);
 
     int place_building(Game &game, int planet_id, int building_id, int x, int y);
     bool remove_building(Game &game, int planet_id, int instance_id);

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1,8 +1,32 @@
 #include "combat.hpp"
 
 CombatManager::CombatManager()
+    : _player_weapon_multiplier(1.0),
+      _player_shield_multiplier(1.0),
+      _player_hull_multiplier(1.0)
 {
     return ;
+}
+
+void CombatManager::set_player_weapon_multiplier(double value)
+{
+    if (value < 1.0)
+        value = 1.0;
+    this->_player_weapon_multiplier = value;
+}
+
+void CombatManager::set_player_shield_multiplier(double value)
+{
+    if (value < 1.0)
+        value = 1.0;
+    this->_player_shield_multiplier = value;
+}
+
+void CombatManager::set_player_hull_multiplier(double value)
+{
+    if (value < 1.0)
+        value = 1.0;
+    this->_player_hull_multiplier = value;
 }
 
 bool CombatManager::start_raider_assault(int planet_id, double difficulty)
@@ -168,7 +192,7 @@ void CombatManager::tick(double seconds, ft_map<int, ft_sharedptr<ft_fleet> > &f
             to_remove.push_back(entries[i].key);
             continue;
         }
-        double player_damage = this->calculate_player_power(defenders) * seconds;
+        double player_damage = this->calculate_player_power(defenders) * seconds * this->_player_weapon_multiplier;
         if (player_damage > 0.0)
         {
             if (player_damage >= encounter.raider_shield)
@@ -209,7 +233,7 @@ void CombatManager::tick(double seconds, ft_map<int, ft_sharedptr<ft_fleet> > &f
                 continue;
             if (fleet->has_operational_ships())
                 defenders_operational = true;
-            leftover = fleet->absorb_damage(leftover);
+            leftover = fleet->absorb_damage(leftover, this->_player_shield_multiplier, this->_player_hull_multiplier);
         }
         if (!defenders_operational || leftover > 0.0)
         {

--- a/src/combat.hpp
+++ b/src/combat.hpp
@@ -40,6 +40,9 @@ private:
     };
 
     ft_map<int, ft_combat_encounter> _encounters;
+    double                           _player_weapon_multiplier;
+    double                           _player_shield_multiplier;
+    double                           _player_hull_multiplier;
 
     void gather_defenders(const ft_combat_encounter &encounter,
         ft_map<int, ft_sharedptr<ft_fleet> > &fleets,
@@ -54,6 +57,10 @@ private:
 
 public:
     CombatManager();
+
+    void set_player_weapon_multiplier(double value);
+    void set_player_shield_multiplier(double value);
+    void set_player_hull_multiplier(double value);
 
     bool start_raider_assault(int planet_id, double difficulty);
     bool add_fleet(int planet_id, int fleet_id);

--- a/src/fleets.hpp
+++ b/src/fleets.hpp
@@ -91,7 +91,7 @@ public:
     int add_ship_shield(int ship_uid, int amount) noexcept;
     int sub_ship_shield(int ship_uid, int amount) noexcept;
 
-    double absorb_damage(double damage) noexcept;
+    double absorb_damage(double damage, double shield_multiplier, double hull_multiplier) noexcept;
     void apply_support(int shield_amount, int repair_amount) noexcept;
     bool has_operational_ships() const noexcept;
 

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -12,6 +12,10 @@
 #include "../libft/Template/map.hpp"
 #include "../libft/Template/vector.hpp"
 
+#define GAME_DIFFICULTY_EASY 1
+#define GAME_DIFFICULTY_STANDARD 2
+#define GAME_DIFFICULTY_HARD 3
+
 class Game
 {
 private:
@@ -26,6 +30,14 @@ private:
     CombatManager                                _combat;
     BuildingManager                              _buildings;
     ft_vector<ft_string>                         _lore_log;
+    int                                          _difficulty;
+    double                                       _resource_multiplier;
+    double                                       _quest_time_scale;
+    double                                       _research_duration_scale;
+    double                                       _assault_difficulty_multiplier;
+    double                                       _ship_weapon_multiplier;
+    double                                       _ship_shield_multiplier;
+    double                                       _ship_hull_multiplier;
 
     ft_sharedptr<ft_planet> get_planet(int id);
     ft_sharedptr<const ft_planet> get_planet(int id) const;
@@ -39,13 +51,21 @@ private:
     void pay_research_cost(const ft_vector<Pair<int, int> > &costs);
     void handle_research_completion(int research_id);
     void build_quest_context(ft_quest_context &context) const;
+    void handle_quest_completion(int quest_id);
+    void handle_quest_failure(int quest_id);
+    void handle_quest_choice_prompt(int quest_id);
+    void handle_quest_choice_resolution(int quest_id, int choice_id);
+    void configure_difficulty(int difficulty);
+    void update_combat_modifiers();
 
 public:
-    Game(const ft_string &host, const ft_string &path);
+    Game(const ft_string &host, const ft_string &path, int difficulty = GAME_DIFFICULTY_STANDARD);
     ~Game();
 
     void produce(double seconds);
     void tick(double seconds);
+
+    int get_difficulty() const { return this->_difficulty; }
 
     bool is_planet_unlocked(int planet_id) const;
 
@@ -90,6 +110,10 @@ public:
     int transfer_ore(int from_planet_id, int to_planet_id, int ore_id, int amount);
     double get_rate(int planet_id, int ore_id) const;
     const ft_vector<Pair<int, double> > &get_planet_resources(int planet_id) const;
+
+    double get_ship_weapon_multiplier() const { return this->_ship_weapon_multiplier; }
+    double get_ship_shield_multiplier() const { return this->_ship_shield_multiplier; }
+    double get_ship_hull_multiplier() const { return this->_ship_hull_multiplier; }
 
     void create_fleet(int fleet_id);
     void remove_fleet(int fleet_id, int target_fleet_id = -1, int target_planet_id = -1);

--- a/src/quests.hpp
+++ b/src/quests.hpp
@@ -101,6 +101,7 @@ private:
     ft_map<int, ft_sharedptr<ft_quest_definition> > _definitions;
     ft_map<int, ft_quest_progress>                  _progress;
     ft_map<int, int>                                _quest_choices;
+    double                                          _time_scale;
 
     void register_quest(const ft_sharedptr<ft_quest_definition> &definition);
     void update_availability();
@@ -113,6 +114,9 @@ public:
     void update(double seconds, const ft_quest_context &context,
                 ft_vector<int> &completed, ft_vector<int> &failed,
                 ft_vector<int> &awaiting_choice);
+
+    void set_time_scale(double scale);
+    double get_time_scale() const { return this->_time_scale; }
 
     int get_active_quest_id() const;
     int get_status(int quest_id) const;

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -1,6 +1,7 @@
 #include "research.hpp"
 
 ResearchManager::ResearchManager()
+    : _duration_scale(1.0)
 {
     ft_sharedptr<ft_research_definition> mars(new ft_research_definition());
     mars->id = RESEARCH_UNLOCK_MARS;
@@ -76,6 +77,229 @@ ResearchManager::ResearchManager()
     noctaris->unlock_planets.push_back(PLANET_NOCTARIS_PRIME);
     this->register_research(noctaris);
 
+    ft_sharedptr<ft_research_definition> planning_terra(new ft_research_definition());
+    planning_terra->id = RESEARCH_URBAN_PLANNING_TERRA;
+    planning_terra->name = ft_string("Urban Planning I");
+    planning_terra->duration = 20.0;
+    planning_terra->prerequisites.clear();
+    planning_terra->costs.clear();
+    cost.key = ITEM_IRON_BAR;
+    cost.value = 15;
+    planning_terra->costs.push_back(cost);
+    cost.key = ITEM_ENGINE_PART;
+    cost.value = 5;
+    planning_terra->costs.push_back(cost);
+    planning_terra->unlock_planets.clear();
+    this->register_research(planning_terra);
+
+    ft_sharedptr<ft_research_definition> planning_mars(new ft_research_definition());
+    planning_mars->id = RESEARCH_URBAN_PLANNING_MARS;
+    planning_mars->name = ft_string("Urban Planning II");
+    planning_mars->duration = 25.0;
+    planning_mars->prerequisites.clear();
+    planning_mars->prerequisites.push_back(RESEARCH_UNLOCK_MARS);
+    planning_mars->costs.clear();
+    cost.key = ITEM_IRON_BAR;
+    cost.value = 30;
+    planning_mars->costs.push_back(cost);
+    cost.key = ITEM_ENGINE_PART;
+    cost.value = 10;
+    planning_mars->costs.push_back(cost);
+    planning_mars->unlock_planets.clear();
+    this->register_research(planning_mars);
+
+    ft_sharedptr<ft_research_definition> planning_zalthor(new ft_research_definition());
+    planning_zalthor->id = RESEARCH_URBAN_PLANNING_ZALTHOR;
+    planning_zalthor->name = ft_string("Urban Planning III");
+    planning_zalthor->duration = 30.0;
+    planning_zalthor->prerequisites.clear();
+    planning_zalthor->prerequisites.push_back(RESEARCH_UNLOCK_ZALTHOR);
+    planning_zalthor->costs.clear();
+    cost.key = ITEM_IRON_BAR;
+    cost.value = 45;
+    planning_zalthor->costs.push_back(cost);
+    cost.key = ITEM_ENGINE_PART;
+    cost.value = 15;
+    planning_zalthor->costs.push_back(cost);
+    planning_zalthor->unlock_planets.clear();
+    this->register_research(planning_zalthor);
+
+    ft_sharedptr<ft_research_definition> solar(new ft_research_definition());
+    solar->id = RESEARCH_SOLAR_PANELS;
+    solar->name = ft_string("Solar Panel Engineering");
+    solar->duration = 25.0;
+    solar->prerequisites.clear();
+    solar->prerequisites.push_back(RESEARCH_UNLOCK_MARS);
+    solar->costs.clear();
+    cost.key = ORE_IRON;
+    cost.value = 20;
+    solar->costs.push_back(cost);
+    cost.key = ORE_COPPER;
+    cost.value = 30;
+    solar->costs.push_back(cost);
+    solar->unlock_planets.clear();
+    this->register_research(solar);
+
+    ft_sharedptr<ft_research_definition> mastery(new ft_research_definition());
+    mastery->id = RESEARCH_CRAFTING_MASTERY;
+    mastery->name = ft_string("Crafting Mastery");
+    mastery->duration = 35.0;
+    mastery->prerequisites.clear();
+    mastery->prerequisites.push_back(RESEARCH_SOLAR_PANELS);
+    mastery->costs.clear();
+    cost.key = ITEM_ENGINE_PART;
+    cost.value = 5;
+    mastery->costs.push_back(cost);
+    cost.key = ORE_TITANIUM;
+    cost.value = 3;
+    mastery->costs.push_back(cost);
+    mastery->unlock_planets.clear();
+    this->register_research(mastery);
+
+    ft_sharedptr<ft_research_definition> structural_i(new ft_research_definition());
+    structural_i->id = RESEARCH_STRUCTURAL_REINFORCEMENT_I;
+    structural_i->name = ft_string("Structural Reinforcement I");
+    structural_i->duration = 25.0;
+    structural_i->prerequisites.clear();
+    structural_i->prerequisites.push_back(RESEARCH_UNLOCK_MARS);
+    structural_i->costs.clear();
+    cost.key = ITEM_IRON_BAR;
+    cost.value = 10;
+    structural_i->costs.push_back(cost);
+    cost.key = ORE_COAL;
+    cost.value = 10;
+    structural_i->costs.push_back(cost);
+    structural_i->unlock_planets.clear();
+    this->register_research(structural_i);
+
+    ft_sharedptr<ft_research_definition> structural_ii(new ft_research_definition());
+    structural_ii->id = RESEARCH_STRUCTURAL_REINFORCEMENT_II;
+    structural_ii->name = ft_string("Structural Reinforcement II");
+    structural_ii->duration = 35.0;
+    structural_ii->prerequisites.clear();
+    structural_ii->prerequisites.push_back(RESEARCH_STRUCTURAL_REINFORCEMENT_I);
+    structural_ii->costs.clear();
+    cost.key = ITEM_IRON_BAR;
+    cost.value = 20;
+    structural_ii->costs.push_back(cost);
+    cost.key = ORE_COAL;
+    cost.value = 20;
+    structural_ii->costs.push_back(cost);
+    structural_ii->unlock_planets.clear();
+    this->register_research(structural_ii);
+
+    ft_sharedptr<ft_research_definition> structural_iii(new ft_research_definition());
+    structural_iii->id = RESEARCH_STRUCTURAL_REINFORCEMENT_III;
+    structural_iii->name = ft_string("Structural Reinforcement III");
+    structural_iii->duration = 45.0;
+    structural_iii->prerequisites.clear();
+    structural_iii->prerequisites.push_back(RESEARCH_STRUCTURAL_REINFORCEMENT_II);
+    structural_iii->costs.clear();
+    cost.key = ITEM_IRON_BAR;
+    cost.value = 30;
+    structural_iii->costs.push_back(cost);
+    cost.key = ORE_COAL;
+    cost.value = 30;
+    structural_iii->costs.push_back(cost);
+    structural_iii->unlock_planets.clear();
+    this->register_research(structural_iii);
+
+    ft_sharedptr<ft_research_definition> defensive_i(new ft_research_definition());
+    defensive_i->id = RESEARCH_DEFENSIVE_FORTIFICATION_I;
+    defensive_i->name = ft_string("Defensive Fortification I");
+    defensive_i->duration = 30.0;
+    defensive_i->prerequisites.clear();
+    defensive_i->prerequisites.push_back(RESEARCH_UNLOCK_ZALTHOR);
+    defensive_i->costs.clear();
+    cost.key = ITEM_COPPER_BAR;
+    cost.value = 10;
+    defensive_i->costs.push_back(cost);
+    cost.key = ITEM_MITHRIL_BAR;
+    cost.value = 5;
+    defensive_i->costs.push_back(cost);
+    defensive_i->unlock_planets.clear();
+    this->register_research(defensive_i);
+
+    ft_sharedptr<ft_research_definition> defensive_ii(new ft_research_definition());
+    defensive_ii->id = RESEARCH_DEFENSIVE_FORTIFICATION_II;
+    defensive_ii->name = ft_string("Defensive Fortification II");
+    defensive_ii->duration = 40.0;
+    defensive_ii->prerequisites.clear();
+    defensive_ii->prerequisites.push_back(RESEARCH_DEFENSIVE_FORTIFICATION_I);
+    defensive_ii->costs.clear();
+    cost.key = ITEM_COPPER_BAR;
+    cost.value = 20;
+    defensive_ii->costs.push_back(cost);
+    cost.key = ITEM_MITHRIL_BAR;
+    cost.value = 10;
+    defensive_ii->costs.push_back(cost);
+    defensive_ii->unlock_planets.clear();
+    this->register_research(defensive_ii);
+
+    ft_sharedptr<ft_research_definition> defensive_iii(new ft_research_definition());
+    defensive_iii->id = RESEARCH_DEFENSIVE_FORTIFICATION_III;
+    defensive_iii->name = ft_string("Defensive Fortification III");
+    defensive_iii->duration = 50.0;
+    defensive_iii->prerequisites.clear();
+    defensive_iii->prerequisites.push_back(RESEARCH_DEFENSIVE_FORTIFICATION_II);
+    defensive_iii->costs.clear();
+    cost.key = ITEM_COPPER_BAR;
+    cost.value = 30;
+    defensive_iii->costs.push_back(cost);
+    cost.key = ITEM_MITHRIL_BAR;
+    cost.value = 15;
+    defensive_iii->costs.push_back(cost);
+    defensive_iii->unlock_planets.clear();
+    this->register_research(defensive_iii);
+
+    ft_sharedptr<ft_research_definition> armament_i(new ft_research_definition());
+    armament_i->id = RESEARCH_ARMAMENT_ENHANCEMENT_I;
+    armament_i->name = ft_string("Armament Enhancement I");
+    armament_i->duration = 35.0;
+    armament_i->prerequisites.clear();
+    armament_i->prerequisites.push_back(RESEARCH_UNLOCK_VULCAN);
+    armament_i->costs.clear();
+    cost.key = ITEM_ENGINE_PART;
+    cost.value = 10;
+    armament_i->costs.push_back(cost);
+    cost.key = ORE_TITANIUM;
+    cost.value = 5;
+    armament_i->costs.push_back(cost);
+    armament_i->unlock_planets.clear();
+    this->register_research(armament_i);
+
+    ft_sharedptr<ft_research_definition> armament_ii(new ft_research_definition());
+    armament_ii->id = RESEARCH_ARMAMENT_ENHANCEMENT_II;
+    armament_ii->name = ft_string("Armament Enhancement II");
+    armament_ii->duration = 45.0;
+    armament_ii->prerequisites.clear();
+    armament_ii->prerequisites.push_back(RESEARCH_ARMAMENT_ENHANCEMENT_I);
+    armament_ii->costs.clear();
+    cost.key = ITEM_ENGINE_PART;
+    cost.value = 20;
+    armament_ii->costs.push_back(cost);
+    cost.key = ORE_TITANIUM;
+    cost.value = 10;
+    armament_ii->costs.push_back(cost);
+    armament_ii->unlock_planets.clear();
+    this->register_research(armament_ii);
+
+    ft_sharedptr<ft_research_definition> armament_iii(new ft_research_definition());
+    armament_iii->id = RESEARCH_ARMAMENT_ENHANCEMENT_III;
+    armament_iii->name = ft_string("Armament Enhancement III");
+    armament_iii->duration = 55.0;
+    armament_iii->prerequisites.clear();
+    armament_iii->prerequisites.push_back(RESEARCH_ARMAMENT_ENHANCEMENT_II);
+    armament_iii->costs.clear();
+    cost.key = ITEM_ENGINE_PART;
+    cost.value = 30;
+    armament_iii->costs.push_back(cost);
+    cost.key = ORE_TITANIUM;
+    cost.value = 15;
+    armament_iii->costs.push_back(cost);
+    armament_iii->unlock_planets.clear();
+    this->register_research(armament_iii);
+
     this->update_availability();
 }
 
@@ -143,6 +367,28 @@ void ResearchManager::tick(double seconds, ft_vector<int> &completed)
         this->update_availability();
 }
 
+void ResearchManager::set_duration_scale(double scale)
+{
+    if (scale <= 0.0)
+        scale = 1.0;
+    double delta = scale - this->_duration_scale;
+    if (delta < 0.0)
+        delta = -delta;
+    if (delta < 0.000001)
+        return ;
+    double ratio = scale / this->_duration_scale;
+    this->_duration_scale = scale;
+    size_t count = this->_progress.size();
+    Pair<int, ft_research_progress> *entries = this->_progress.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        ft_research_progress &progress = entries[i].value;
+        if (progress.status == RESEARCH_STATUS_IN_PROGRESS && progress.remaining_time > 0.0)
+            progress.remaining_time *= ratio;
+    }
+}
+
 bool ResearchManager::can_start(int research_id) const
 {
     const Pair<int, ft_research_progress> *entry = this->_progress.find(research_id);
@@ -162,7 +408,11 @@ bool ResearchManager::start(int research_id)
     if (definition == ft_nullptr)
         return false;
     entry->value.status = RESEARCH_STATUS_IN_PROGRESS;
-    entry->value.remaining_time = definition->duration;
+    double scaled = definition->duration * this->_duration_scale;
+    if (scaled <= 0.0)
+        entry->value.remaining_time = 0.0;
+    else
+        entry->value.remaining_time = scaled;
     if (entry->value.remaining_time <= 0.0)
     {
         entry->value.remaining_time = 0.0;

--- a/src/research.hpp
+++ b/src/research.hpp
@@ -14,7 +14,21 @@ enum e_research_id
     RESEARCH_UNLOCK_MARS = 1,
     RESEARCH_UNLOCK_ZALTHOR,
     RESEARCH_UNLOCK_VULCAN,
-    RESEARCH_UNLOCK_NOCTARIS
+    RESEARCH_UNLOCK_NOCTARIS,
+    RESEARCH_URBAN_PLANNING_TERRA,
+    RESEARCH_URBAN_PLANNING_MARS,
+    RESEARCH_URBAN_PLANNING_ZALTHOR,
+    RESEARCH_SOLAR_PANELS,
+    RESEARCH_CRAFTING_MASTERY,
+    RESEARCH_STRUCTURAL_REINFORCEMENT_I,
+    RESEARCH_STRUCTURAL_REINFORCEMENT_II,
+    RESEARCH_STRUCTURAL_REINFORCEMENT_III,
+    RESEARCH_DEFENSIVE_FORTIFICATION_I,
+    RESEARCH_DEFENSIVE_FORTIFICATION_II,
+    RESEARCH_DEFENSIVE_FORTIFICATION_III,
+    RESEARCH_ARMAMENT_ENHANCEMENT_I,
+    RESEARCH_ARMAMENT_ENHANCEMENT_II,
+    RESEARCH_ARMAMENT_ENHANCEMENT_III
 };
 
 enum e_research_status
@@ -47,6 +61,7 @@ class ResearchManager
 private:
     ft_map<int, ft_sharedptr<ft_research_definition> > _definitions;
     ft_map<int, ft_research_progress>   _progress;
+    double                              _duration_scale;
 
     void register_research(const ft_sharedptr<ft_research_definition> &definition);
     void update_availability();
@@ -55,6 +70,9 @@ public:
     ResearchManager();
 
     void tick(double seconds, ft_vector<int> &completed);
+
+    void set_duration_scale(double scale);
+    double get_duration_scale() const { return this->_duration_scale; }
 
     bool can_start(int research_id) const;
     bool start(int research_id);

--- a/test_failures.log
+++ b/test_failures.log
@@ -1,0 +1,2 @@
+# Test failure log
+# No outstanding failures. Remove resolved entries when issues are fixed.

--- a/tests/game_test.cpp
+++ b/tests/game_test.cpp
@@ -15,10 +15,8 @@ static void run_server()
 {
     ft_http_server server;
     server.start("127.0.0.1", 8080, AF_INET, false);
-    server.run_once();
-    server.run_once();
-    server.run_once();
-    server.run_once();
+    for (int i = 0; i < 64; ++i)
+        server.run_once();
 }
 
 int main()
@@ -34,6 +32,7 @@ int main()
     FT_ASSERT_EQ(0, ft_strcmp(resp + response.size() - 4, "test"));
 
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    FT_ASSERT_EQ(GAME_DIFFICULTY_STANDARD, game.get_difficulty());
     FT_ASSERT(game.is_planet_unlocked(PLANET_TERRA));
     FT_ASSERT(!game.is_planet_unlocked(PLANET_MARS));
     FT_ASSERT(!game.is_planet_unlocked(PLANET_ZALTHOR));
@@ -44,6 +43,8 @@ int main()
     FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_UNLOCK_ZALTHOR));
     FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_UNLOCK_VULCAN));
     FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_UNLOCK_NOCTARIS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_SOLAR_PANELS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_CRAFTING_MASTERY));
     FT_ASSERT(!game.can_start_research(RESEARCH_UNLOCK_MARS));
     FT_ASSERT(!game.can_start_research(RESEARCH_UNLOCK_ZALTHOR));
 
@@ -54,6 +55,7 @@ int main()
     FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_CLIMACTIC_BATTLE));
     FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_CRITICAL_DECISION));
     FT_ASSERT_EQ(QUEST_CHOICE_NONE, game.get_quest_choice(QUEST_CRITICAL_DECISION));
+    game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 0);
 
     int ore = game.add_ore(PLANET_TERRA, ORE_COPPER, 5);
     FT_ASSERT_EQ(5, ore);
@@ -79,6 +81,22 @@ int main()
     FT_ASSERT_EQ(QUEST_STATUS_COMPLETED, game.get_quest_status(QUEST_INITIAL_SKIRMISHES));
     FT_ASSERT_EQ(QUEST_DEFENSE_OF_TERRA, game.get_active_quest());
     FT_ASSERT_EQ(QUEST_STATUS_ACTIVE, game.get_quest_status(QUEST_DEFENSE_OF_TERRA));
+    int parts_after_skirmish = game.get_ore(PLANET_TERRA, ITEM_ENGINE_PART);
+    FT_ASSERT(parts_after_skirmish >= 2);
+    double defense_timer = game.get_quest_time_remaining(QUEST_DEFENSE_OF_TERRA);
+    FT_ASSERT(defense_timer > 179.9 && defense_timer < 180.1);
+    size_t lore_before_failure = game.get_lore_log().size();
+    game.tick(200.0);
+    int parts_after_failure = game.get_ore(PLANET_TERRA, ITEM_ENGINE_PART);
+    FT_ASSERT(parts_after_failure < parts_after_skirmish);
+    size_t lore_after_failure = game.get_lore_log().size();
+    FT_ASSERT(lore_after_failure > lore_before_failure);
+    FT_ASSERT_EQ(QUEST_STATUS_ACTIVE, game.get_quest_status(QUEST_DEFENSE_OF_TERRA));
+    defense_timer = game.get_quest_time_remaining(QUEST_DEFENSE_OF_TERRA);
+    FT_ASSERT(defense_timer > 179.9 && defense_timer < 180.1);
+    game.set_ore(PLANET_TERRA, ORE_IRON, 40);
+    game.set_ore(PLANET_TERRA, ORE_COPPER, 30);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 12);
     FT_ASSERT(game.can_start_research(RESEARCH_UNLOCK_MARS));
     FT_ASSERT(game.start_research(RESEARCH_UNLOCK_MARS));
     FT_ASSERT_EQ(RESEARCH_STATUS_IN_PROGRESS, game.get_research_status(RESEARCH_UNLOCK_MARS));
@@ -91,6 +109,8 @@ int main()
     FT_ASSERT(game.is_planet_unlocked(PLANET_MARS));
     FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_UNLOCK_MARS));
     FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_UNLOCK_ZALTHOR));
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_SOLAR_PANELS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_CRAFTING_MASTERY));
     double mithril_rate = game.get_rate(PLANET_MARS, ORE_MITHRIL);
     FT_ASSERT(mithril_rate > 0.049 && mithril_rate < 0.051);
 
@@ -142,6 +162,8 @@ int main()
     FT_ASSERT_EQ(QUEST_STATUS_AWAITING_CHOICE, game.get_quest_status(QUEST_CRITICAL_DECISION));
     FT_ASSERT(game.resolve_quest_choice(QUEST_CRITICAL_DECISION, QUEST_CHOICE_SPARE_BLACKTHORNE));
     FT_ASSERT_EQ(QUEST_CHOICE_SPARE_BLACKTHORNE, game.get_quest_choice(QUEST_CRITICAL_DECISION));
+    int crystal_reward = game.get_ore(PLANET_TERRA, ORE_CRYSTAL);
+    FT_ASSERT(crystal_reward >= 3);
     FT_ASSERT_EQ(QUEST_STATUS_LOCKED, game.get_quest_status(QUEST_ORDER_UPRISING));
     FT_ASSERT_EQ(QUEST_REBELLION_FLEET, game.get_active_quest());
     FT_ASSERT_EQ(QUEST_STATUS_ACTIVE, game.get_quest_status(QUEST_REBELLION_FLEET));
@@ -348,6 +370,7 @@ int main()
     game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 0);
     game.set_ore(PLANET_TERRA, ITEM_COPPER_BAR, 0);
 
+    FT_ASSERT(!game.can_place_building(PLANET_TERRA, BUILDING_SOLAR_ARRAY, 0, 1));
     FT_ASSERT(game.can_place_building(PLANET_TERRA, BUILDING_POWER_GENERATOR, 2, 0));
     int terra_generator = game.place_building(PLANET_TERRA, BUILDING_POWER_GENERATOR, 2, 0);
     FT_ASSERT(terra_generator != 0);
@@ -401,6 +424,198 @@ int main()
     FT_ASSERT(terra_use_after > 4.49 && terra_use_after < 4.51);
     double terra_mine_bonus = game.get_planet_mine_multiplier(PLANET_TERRA);
     FT_ASSERT(terra_mine_bonus > 0.99 && terra_mine_bonus < 1.01);
+
+    int terra_capacity_before = game.get_planet_logistic_capacity(PLANET_TERRA);
+    game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 80);
+    game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 20);
+    FT_ASSERT(game.can_start_research(RESEARCH_URBAN_PLANNING_TERRA));
+    FT_ASSERT(game.start_research(RESEARCH_URBAN_PLANNING_TERRA));
+    double terra_planning_remaining = game.get_research_time_remaining(RESEARCH_URBAN_PLANNING_TERRA);
+    FT_ASSERT(terra_planning_remaining > 19.9 && terra_planning_remaining < 20.1);
+    game.tick(20.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_URBAN_PLANNING_TERRA));
+    FT_ASSERT(game.get_planet_logistic_capacity(PLANET_TERRA) >= terra_capacity_before + 4);
+
+    int mars_capacity_before = game.get_planet_logistic_capacity(PLANET_MARS);
+    game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 160);
+    game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 40);
+    FT_ASSERT(game.can_start_research(RESEARCH_URBAN_PLANNING_MARS));
+    FT_ASSERT(game.start_research(RESEARCH_URBAN_PLANNING_MARS));
+    double mars_planning_remaining = game.get_research_time_remaining(RESEARCH_URBAN_PLANNING_MARS);
+    FT_ASSERT(mars_planning_remaining > 24.9 && mars_planning_remaining < 25.1);
+    game.tick(25.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_URBAN_PLANNING_MARS));
+    FT_ASSERT(game.get_planet_logistic_capacity(PLANET_MARS) >= mars_capacity_before + 4);
+
+    int zalthor_capacity_before = game.get_planet_logistic_capacity(PLANET_ZALTHOR);
+    game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 240);
+    game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 80);
+    FT_ASSERT(game.can_start_research(RESEARCH_URBAN_PLANNING_ZALTHOR));
+    FT_ASSERT(game.start_research(RESEARCH_URBAN_PLANNING_ZALTHOR));
+    double zalthor_planning_remaining = game.get_research_time_remaining(RESEARCH_URBAN_PLANNING_ZALTHOR);
+    FT_ASSERT(zalthor_planning_remaining > 29.9 && zalthor_planning_remaining < 30.1);
+    game.tick(30.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_URBAN_PLANNING_ZALTHOR));
+    FT_ASSERT(game.get_planet_logistic_capacity(PLANET_ZALTHOR) >= zalthor_capacity_before + 4);
+
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_SOLAR_PANELS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_CRAFTING_MASTERY));
+    game.set_ore(PLANET_TERRA, ORE_IRON, 240);
+    game.set_ore(PLANET_TERRA, ORE_COPPER, 240);
+    FT_ASSERT(game.can_start_research(RESEARCH_SOLAR_PANELS));
+    FT_ASSERT(game.start_research(RESEARCH_SOLAR_PANELS));
+    double solar_remaining = game.get_research_time_remaining(RESEARCH_SOLAR_PANELS);
+    FT_ASSERT(solar_remaining > 24.9 && solar_remaining < 25.1);
+    game.tick(25.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_SOLAR_PANELS));
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_CRAFTING_MASTERY));
+    FT_ASSERT(game.can_place_building(PLANET_TERRA, BUILDING_SOLAR_ARRAY, 0, 1));
+    int solar_instance = game.place_building(PLANET_TERRA, BUILDING_SOLAR_ARRAY, 0, 1);
+    FT_ASSERT(solar_instance != 0);
+    double terra_energy_with_solar = game.get_planet_energy_generation(PLANET_TERRA);
+    FT_ASSERT(terra_energy_with_solar > 8.9 && terra_energy_with_solar < 9.1);
+
+    game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 260);
+    game.set_ore(PLANET_TERRA, ORE_TITANIUM, 260);
+    FT_ASSERT(game.can_start_research(RESEARCH_CRAFTING_MASTERY));
+    FT_ASSERT(game.start_research(RESEARCH_CRAFTING_MASTERY));
+    double mastery_remaining = game.get_research_time_remaining(RESEARCH_CRAFTING_MASTERY);
+    FT_ASSERT(mastery_remaining > 34.9 && mastery_remaining < 35.1);
+    game.tick(35.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_CRAFTING_MASTERY));
+    game.tick(10.0);
+    double terra_energy_mastery = game.get_planet_energy_consumption(PLANET_TERRA);
+    FT_ASSERT(terra_energy_mastery > 3.5 && terra_energy_mastery < 3.7);
+    FT_ASSERT(terra_energy_mastery < terra_use_after - 0.7);
+    FT_ASSERT(game.get_planet_logistic_usage(PLANET_TERRA) >= 2);
+
+    FT_ASSERT(game.get_ship_hull_multiplier() > 0.99 && game.get_ship_hull_multiplier() < 1.01);
+    FT_ASSERT(game.get_ship_shield_multiplier() > 0.99 && game.get_ship_shield_multiplier() < 1.01);
+    FT_ASSERT(game.get_ship_weapon_multiplier() > 0.99 && game.get_ship_weapon_multiplier() < 1.01);
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_STRUCTURAL_REINFORCEMENT_I));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_STRUCTURAL_REINFORCEMENT_II));
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_DEFENSIVE_FORTIFICATION_I));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_DEFENSIVE_FORTIFICATION_II));
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_ARMAMENT_ENHANCEMENT_I));
+    FT_ASSERT_EQ(RESEARCH_STATUS_LOCKED, game.get_research_status(RESEARCH_ARMAMENT_ENHANCEMENT_II));
+
+    game.ensure_planet_item_slot(PLANET_TERRA, ITEM_IRON_BAR);
+    game.ensure_planet_item_slot(PLANET_TERRA, ORE_COAL);
+    game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 220);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 220);
+    FT_ASSERT(game.can_start_research(RESEARCH_STRUCTURAL_REINFORCEMENT_I));
+    FT_ASSERT(game.start_research(RESEARCH_STRUCTURAL_REINFORCEMENT_I));
+    double structural_one = game.get_research_time_remaining(RESEARCH_STRUCTURAL_REINFORCEMENT_I);
+    FT_ASSERT(structural_one > 24.9 && structural_one < 25.1);
+    game.tick(25.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_STRUCTURAL_REINFORCEMENT_I));
+    FT_ASSERT(game.get_ship_hull_multiplier() > 1.09 && game.get_ship_hull_multiplier() < 1.11);
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_STRUCTURAL_REINFORCEMENT_II));
+    game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 260);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 260);
+    FT_ASSERT(game.can_start_research(RESEARCH_STRUCTURAL_REINFORCEMENT_II));
+    FT_ASSERT(game.start_research(RESEARCH_STRUCTURAL_REINFORCEMENT_II));
+    double structural_two = game.get_research_time_remaining(RESEARCH_STRUCTURAL_REINFORCEMENT_II);
+    FT_ASSERT(structural_two > 34.9 && structural_two < 35.1);
+    game.tick(35.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_STRUCTURAL_REINFORCEMENT_II));
+    FT_ASSERT(game.get_ship_hull_multiplier() > 1.19 && game.get_ship_hull_multiplier() < 1.21);
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_STRUCTURAL_REINFORCEMENT_III));
+    game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 320);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 320);
+    FT_ASSERT(game.can_start_research(RESEARCH_STRUCTURAL_REINFORCEMENT_III));
+    FT_ASSERT(game.start_research(RESEARCH_STRUCTURAL_REINFORCEMENT_III));
+    double structural_three = game.get_research_time_remaining(RESEARCH_STRUCTURAL_REINFORCEMENT_III);
+    FT_ASSERT(structural_three > 44.9 && structural_three < 45.1);
+    game.tick(45.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_STRUCTURAL_REINFORCEMENT_III));
+    FT_ASSERT(game.get_ship_hull_multiplier() > 1.29 && game.get_ship_hull_multiplier() < 1.31);
+
+    game.ensure_planet_item_slot(PLANET_TERRA, ITEM_COPPER_BAR);
+    game.ensure_planet_item_slot(PLANET_TERRA, ITEM_MITHRIL_BAR);
+    game.set_ore(PLANET_TERRA, ITEM_COPPER_BAR, 220);
+    game.set_ore(PLANET_TERRA, ITEM_MITHRIL_BAR, 220);
+    FT_ASSERT(game.can_start_research(RESEARCH_DEFENSIVE_FORTIFICATION_I));
+    FT_ASSERT(game.start_research(RESEARCH_DEFENSIVE_FORTIFICATION_I));
+    double defensive_one = game.get_research_time_remaining(RESEARCH_DEFENSIVE_FORTIFICATION_I);
+    FT_ASSERT(defensive_one > 29.9 && defensive_one < 30.1);
+    game.tick(30.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_DEFENSIVE_FORTIFICATION_I));
+    FT_ASSERT(game.get_ship_shield_multiplier() > 1.09 && game.get_ship_shield_multiplier() < 1.11);
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_DEFENSIVE_FORTIFICATION_II));
+    game.set_ore(PLANET_TERRA, ITEM_COPPER_BAR, 260);
+    game.set_ore(PLANET_TERRA, ITEM_MITHRIL_BAR, 260);
+    FT_ASSERT(game.can_start_research(RESEARCH_DEFENSIVE_FORTIFICATION_II));
+    FT_ASSERT(game.start_research(RESEARCH_DEFENSIVE_FORTIFICATION_II));
+    double defensive_two = game.get_research_time_remaining(RESEARCH_DEFENSIVE_FORTIFICATION_II);
+    FT_ASSERT(defensive_two > 39.9 && defensive_two < 40.1);
+    game.tick(40.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_DEFENSIVE_FORTIFICATION_II));
+    FT_ASSERT(game.get_ship_shield_multiplier() > 1.19 && game.get_ship_shield_multiplier() < 1.21);
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_DEFENSIVE_FORTIFICATION_III));
+    game.set_ore(PLANET_TERRA, ITEM_COPPER_BAR, 320);
+    game.set_ore(PLANET_TERRA, ITEM_MITHRIL_BAR, 320);
+    FT_ASSERT(game.can_start_research(RESEARCH_DEFENSIVE_FORTIFICATION_III));
+    FT_ASSERT(game.start_research(RESEARCH_DEFENSIVE_FORTIFICATION_III));
+    double defensive_three = game.get_research_time_remaining(RESEARCH_DEFENSIVE_FORTIFICATION_III);
+    FT_ASSERT(defensive_three > 49.9 && defensive_three < 50.1);
+    game.tick(50.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_DEFENSIVE_FORTIFICATION_III));
+    FT_ASSERT(game.get_ship_shield_multiplier() > 1.29 && game.get_ship_shield_multiplier() < 1.31);
+
+    game.ensure_planet_item_slot(PLANET_TERRA, ITEM_ENGINE_PART);
+    game.ensure_planet_item_slot(PLANET_TERRA, ORE_TITANIUM);
+    game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 220);
+    game.set_ore(PLANET_TERRA, ORE_TITANIUM, 220);
+    FT_ASSERT(game.can_start_research(RESEARCH_ARMAMENT_ENHANCEMENT_I));
+    FT_ASSERT(game.start_research(RESEARCH_ARMAMENT_ENHANCEMENT_I));
+    double armament_one = game.get_research_time_remaining(RESEARCH_ARMAMENT_ENHANCEMENT_I);
+    FT_ASSERT(armament_one > 34.9 && armament_one < 35.1);
+    game.tick(35.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_ARMAMENT_ENHANCEMENT_I));
+    FT_ASSERT(game.get_ship_weapon_multiplier() > 1.09 && game.get_ship_weapon_multiplier() < 1.11);
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_ARMAMENT_ENHANCEMENT_II));
+    game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 260);
+    game.set_ore(PLANET_TERRA, ORE_TITANIUM, 260);
+    FT_ASSERT(game.can_start_research(RESEARCH_ARMAMENT_ENHANCEMENT_II));
+    FT_ASSERT(game.start_research(RESEARCH_ARMAMENT_ENHANCEMENT_II));
+    double armament_two = game.get_research_time_remaining(RESEARCH_ARMAMENT_ENHANCEMENT_II);
+    FT_ASSERT(armament_two > 44.9 && armament_two < 45.1);
+    game.tick(45.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_ARMAMENT_ENHANCEMENT_II));
+    FT_ASSERT(game.get_ship_weapon_multiplier() > 1.19 && game.get_ship_weapon_multiplier() < 1.21);
+    FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_ARMAMENT_ENHANCEMENT_III));
+    game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 320);
+    game.set_ore(PLANET_TERRA, ORE_TITANIUM, 320);
+    FT_ASSERT(game.can_start_research(RESEARCH_ARMAMENT_ENHANCEMENT_III));
+    FT_ASSERT(game.start_research(RESEARCH_ARMAMENT_ENHANCEMENT_III));
+    double armament_three = game.get_research_time_remaining(RESEARCH_ARMAMENT_ENHANCEMENT_III);
+    FT_ASSERT(armament_three > 54.9 && armament_three < 55.1);
+    game.tick(55.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_ARMAMENT_ENHANCEMENT_III));
+    FT_ASSERT(game.get_ship_weapon_multiplier() > 1.29 && game.get_ship_weapon_multiplier() < 1.31);
+
+    Game hard_game(ft_string("127.0.0.1:8080"), ft_string("/"), GAME_DIFFICULTY_HARD);
+    FT_ASSERT_EQ(GAME_DIFFICULTY_HARD, hard_game.get_difficulty());
+    hard_game.set_ore(PLANET_TERRA, ORE_IRON, 40);
+    hard_game.set_ore(PLANET_TERRA, ORE_COPPER, 30);
+    hard_game.set_ore(PLANET_TERRA, ORE_COAL, 12);
+    hard_game.tick(0.0);
+    double hard_defense_timer = hard_game.get_quest_time_remaining(QUEST_DEFENSE_OF_TERRA);
+    FT_ASSERT(hard_defense_timer > 134.9 && hard_defense_timer < 135.1);
+    hard_game.set_ore(PLANET_TERRA, ORE_IRON, 0);
+    hard_game.produce(10.0);
+    int hard_iron_yield = hard_game.get_ore(PLANET_TERRA, ORE_IRON);
+    FT_ASSERT(hard_iron_yield <= 4);
+    hard_game.set_ore(PLANET_TERRA, ORE_IRON, 40);
+    hard_game.set_ore(PLANET_TERRA, ORE_COPPER, 30);
+    hard_game.set_ore(PLANET_TERRA, ORE_COAL, 12);
+    FT_ASSERT(hard_game.start_research(RESEARCH_UNLOCK_MARS));
+    double hard_research_time = hard_game.get_research_time_remaining(RESEARCH_UNLOCK_MARS);
+    FT_ASSERT(hard_research_time > 35.9 && hard_research_time < 36.1);
+    FT_ASSERT(hard_game.start_raider_assault(PLANET_TERRA, 1.0));
+    double hard_shield = hard_game.get_assault_raider_shield(PLANET_TERRA);
+    FT_ASSERT(hard_shield > 99.9 && hard_shield < 100.1);
 
     server_thread.join();
     return 0;


### PR DESCRIPTION
## Summary
- add a solar array building definition gated behind new solar panel research and reduce crafting energy via a global multiplier
- introduce Solar Panel Engineering and Crafting Mastery research tiers that unlock the building and update the building manager through the game flow
- expand the integration test to cover research availability, solar placement, and the reduced energy consumption after completing crafting mastery

## Testing
- make
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68ca47a2394083319ecef26abd8b0ffc