### PR TITLE
Track fractional ore production

### DIFF
--- a/src/planets.hpp
+++ b/src/planets.hpp
@@ -52,9 +52,12 @@ protected:
     int                                     _id;
     ft_vector<Pair<int, ft_sharedptr<ft_item> > > _items;
     ft_vector<Pair<int, double> >           _rates;
+    ft_vector<Pair<int, double> >           _carryover;
 
     ft_sharedptr<ft_item> find_item(int ore_id) noexcept;
     ft_sharedptr<const ft_item> find_item(int ore_id) const noexcept;
+    Pair<int, double> *find_carryover(int ore_id) noexcept;
+    const Pair<int, double> *find_carryover(int ore_id) const noexcept;
 
 public:
     explicit ft_planet(int id) noexcept;

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -2,6 +2,7 @@
 #include "../libft/System_utils/test_runner.hpp"
 #include "backend_client.hpp"
 #include "game_test_scenarios.hpp"
+#include "planets.hpp"
 
 int verify_backend_roundtrip()
 {
@@ -11,5 +12,38 @@ int verify_backend_roundtrip()
     const char *resp = response.c_str();
     FT_ASSERT(response.size() >= 4);
     FT_ASSERT_EQ(0, ft_strcmp(resp + response.size() - 4, "test"));
+    return 1;
+}
+
+int verify_fractional_resource_accumulation()
+{
+    ft_planet_mars planet;
+    planet.set_resource(ORE_IRON, 0);
+    planet.set_resource(ORE_COPPER, 0);
+
+    for (int i = 0; i < 9; ++i)
+        planet.produce(1.0);
+    FT_ASSERT_EQ(0, planet.get_resource(ORE_IRON));
+    FT_ASSERT_EQ(0, planet.get_resource(ORE_COPPER));
+
+    ft_vector<Pair<int, int> > final_tick = planet.produce(1.0);
+    bool found_iron = false;
+    for (size_t i = 0; i < final_tick.size(); ++i)
+    {
+        if (final_tick[i].key == ORE_IRON)
+        {
+            FT_ASSERT_EQ(1, final_tick[i].value);
+            found_iron = true;
+        }
+    }
+    FT_ASSERT(found_iron);
+    FT_ASSERT_EQ(1, planet.get_resource(ORE_IRON));
+    FT_ASSERT_EQ(1, planet.get_resource(ORE_COPPER));
+
+    for (int i = 0; i < 10; ++i)
+        planet.produce(1.0);
+    FT_ASSERT_EQ(2, planet.get_resource(ORE_IRON));
+    FT_ASSERT_EQ(2, planet.get_resource(ORE_COPPER));
+
     return 1;
 }

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -23,6 +23,8 @@ int main()
     if (!verify_backend_roundtrip())
         return 0;
 
+    if (!verify_fractional_resource_accumulation())
+        return 0;
 
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
     if (!validate_initial_campaign_flow(game))

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -18,5 +18,6 @@ int inspect_support_ship_positioning();
 int verify_difficulty_scaling();
 int verify_crafting_and_energy_research();
 int verify_auxiliary_and_escape_protocol();
+int verify_fractional_resource_accumulation();
 
 #endif


### PR DESCRIPTION
## Summary
- add per-resource carryover tracking on planets to accumulate fractional mining output between ticks
- update fractional production handling and extend test coverage to confirm low rates produce periodic resources

## Testing
- make test *(fails: missing libft/Full_Libft.a target in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cb111fd90c83318ca4d475506aa820