### PR TITLE
Iterate production over unlocked planets

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -50,19 +50,13 @@ Game::~Game()
 
 void Game::produce(double seconds)
 {
-    int planet_ids[] = {
-        PLANET_TERRA,
-        PLANET_MARS,
-        PLANET_ZALTHOR,
-        PLANET_VULCAN,
-        PLANET_NOCTARIS_PRIME,
-        PLANET_LUNA
-    };
-    size_t count = sizeof(planet_ids) / sizeof(planet_ids[0]);
-    for (size_t i = 0; i < count; ++i)
+    size_t planet_count = this->_planets.size();
+    Pair<int, ft_sharedptr<ft_planet> > *entries = this->_planets.end();
+    entries -= planet_count;
+    for (size_t i = 0; i < planet_count; ++i)
     {
-        int planet_id = planet_ids[i];
-        ft_sharedptr<ft_planet> planet = this->get_planet(planet_id);
+        int planet_id = entries[i].key;
+        ft_sharedptr<ft_planet> planet = entries[i].value;
         if (!planet)
             continue;
         ft_vector<Pair<int, int> > produced = planet->produce(seconds);

--- a/tests/game_test_campaign.cpp
+++ b/tests/game_test_campaign.cpp
@@ -94,6 +94,13 @@ int validate_initial_campaign_flow(Game &game)
     double mithril_rate = game.get_rate(PLANET_MARS, ORE_MITHRIL);
     FT_ASSERT(mithril_rate > 0.049 && mithril_rate < 0.051);
 
+    game.set_ore(PLANET_MARS, ORE_IRON, 0);
+    game.set_ore(PLANET_MARS, ORE_COPPER, 0);
+    game.set_ore(PLANET_MARS, ORE_MITHRIL, 0);
+    game.set_ore(PLANET_MARS, ORE_COAL, 0);
+    game.produce(40.0);
+    FT_ASSERT(game.get_ore(PLANET_MARS, ORE_MITHRIL) >= 2);
+
     FT_ASSERT_EQ(RESEARCH_STATUS_AVAILABLE, game.get_research_status(RESEARCH_UNLOCK_LUNA));
     game.set_ore(PLANET_TERRA, ORE_IRON, 70);
     game.set_ore(PLANET_TERRA, ORE_COPPER, 50);


### PR DESCRIPTION
## Summary
- iterate `Game::produce` over the unlocked planet map instead of a fixed id list
- extend the campaign flow test to confirm newly unlocked planets begin producing resources immediately

## Testing
- `make test` *(fails: libft submodule is empty so Full_Libft.a cannot be built)*

------
https://chatgpt.com/codex/tasks/task_e_68cb14058d208331bccbc86f9ad27123