### PR TITLE
Use composite route keys for supply routes

### DIFF
--- a/src/game.hpp
+++ b/src/game.hpp
@@ -20,6 +20,22 @@
 class Game
 {
 private:
+    struct RouteKey
+    {
+        int origin;
+        int destination;
+
+        RouteKey() : origin(0), destination(0) {}
+        RouteKey(int o, int d) : origin(o), destination(d) {}
+
+        bool operator==(const RouteKey &other) const
+        {
+            return this->origin == other.origin && this->destination == other.destination;
+        }
+    };
+
+    friend int verify_supply_route_key_collisions();
+
     ft_game_state                                 _state;
     ft_map<int, ft_sharedptr<ft_planet> >         _planets;
     ft_map<int, ft_sharedptr<ft_planet> >         _locked_planets;
@@ -78,8 +94,8 @@ private:
               destroyed(false)
         {}
     };
-    ft_map<int, ft_supply_route>                 _supply_routes;
-    ft_map<int, int>                             _route_lookup;
+    ft_map<RouteKey, ft_supply_route>            _supply_routes;
+    ft_map<int, RouteKey>                        _route_lookup;
     ft_map<int, ft_supply_convoy>                _active_convoys;
     int                                          _next_route_id;
     int                                          _next_convoy_id;
@@ -106,7 +122,7 @@ private:
     int count_capital_ships() const;
     void clear_escape_pod_records(const ft_fleet &fleet);
     bool is_ship_type_available(int ship_type) const;
-    int compose_route_key(int origin, int destination) const;
+    RouteKey compose_route_key(int origin, int destination) const;
     ft_supply_route *ensure_supply_route(int origin, int destination);
     const ft_supply_route *get_route_by_id(int route_id) const;
     double estimate_route_travel_time(int origin, int destination) const;

--- a/src/game_convoys.cpp
+++ b/src/game_convoys.cpp
@@ -2,17 +2,17 @@
 #include "../libft/Libft/libft.hpp"
 #include "../libft/Template/pair.hpp"
 
-int Game::compose_route_key(int origin, int destination) const
+Game::RouteKey Game::compose_route_key(int origin, int destination) const
 {
-    return origin * 256 + destination;
+    return RouteKey(origin, destination);
 }
 
 Game::ft_supply_route *Game::ensure_supply_route(int origin, int destination)
 {
     if (origin == destination)
         return ft_nullptr;
-    int key = this->compose_route_key(origin, destination);
-    Pair<int, ft_supply_route> *entry = this->_supply_routes.find(key);
+    RouteKey key = this->compose_route_key(origin, destination);
+    Pair<RouteKey, ft_supply_route> *entry = this->_supply_routes.find(key);
     if (entry != ft_nullptr)
         return &entry->value;
     ft_supply_route route;
@@ -32,10 +32,10 @@ Game::ft_supply_route *Game::ensure_supply_route(int origin, int destination)
 
 const Game::ft_supply_route *Game::get_route_by_id(int route_id) const
 {
-    const Pair<int, int> *lookup = this->_route_lookup.find(route_id);
+    const Pair<int, RouteKey> *lookup = this->_route_lookup.find(route_id);
     if (lookup == ft_nullptr)
         return ft_nullptr;
-    const Pair<int, ft_supply_route> *entry = this->_supply_routes.find(lookup->value);
+    const Pair<RouteKey, ft_supply_route> *entry = this->_supply_routes.find(lookup->value);
     if (entry == ft_nullptr)
         return ft_nullptr;
     return &entry->value;

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -47,3 +47,54 @@ int verify_fractional_resource_accumulation()
 
     return 1;
 }
+
+int verify_supply_route_key_collisions()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+
+    Game::ft_supply_route *first = game.ensure_supply_route(65000, 70000);
+    FT_ASSERT(first != ft_nullptr);
+    int first_id = first->id;
+
+    Game::ft_supply_route *second = game.ensure_supply_route(65000, 70001);
+    FT_ASSERT(second != ft_nullptr);
+    FT_ASSERT(second != first);
+    FT_ASSERT(first_id != second->id);
+
+    Game::ft_supply_route *swapped = game.ensure_supply_route(70000, 65000);
+    FT_ASSERT(swapped != ft_nullptr);
+    FT_ASSERT(swapped != first);
+    FT_ASSERT(swapped != second);
+
+    Game::ft_supply_route *first_again = game.ensure_supply_route(65000, 70000);
+    FT_ASSERT(first_again == first);
+    FT_ASSERT_EQ(first_id, first_again->id);
+
+    const Game::ft_supply_route *lookup_first = game.get_route_by_id(first_id);
+    FT_ASSERT(lookup_first != ft_nullptr);
+    FT_ASSERT_EQ(65000, lookup_first->origin_planet_id);
+    FT_ASSERT_EQ(70000, lookup_first->destination_planet_id);
+
+    const Game::ft_supply_route *lookup_second = game.get_route_by_id(second->id);
+    FT_ASSERT(lookup_second != ft_nullptr);
+    FT_ASSERT_EQ(65000, lookup_second->origin_planet_id);
+    FT_ASSERT_EQ(70001, lookup_second->destination_planet_id);
+
+    const Game::ft_supply_route *lookup_swapped = game.get_route_by_id(swapped->id);
+    FT_ASSERT(lookup_swapped != ft_nullptr);
+    FT_ASSERT_EQ(70000, lookup_swapped->origin_planet_id);
+    FT_ASSERT_EQ(65000, lookup_swapped->destination_planet_id);
+
+    Game::ft_supply_route *third = game.ensure_supply_route(131072, 196608);
+    FT_ASSERT(third != ft_nullptr);
+    FT_ASSERT(third != first);
+    FT_ASSERT(third != second);
+    FT_ASSERT(third != swapped);
+
+    const Game::ft_supply_route *lookup_third = game.get_route_by_id(third->id);
+    FT_ASSERT(lookup_third != ft_nullptr);
+    FT_ASSERT_EQ(131072, lookup_third->origin_planet_id);
+    FT_ASSERT_EQ(196608, lookup_third->destination_planet_id);
+
+    return 1;
+}

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -26,6 +26,9 @@ int main()
     if (!verify_fractional_resource_accumulation())
         return 0;
 
+    if (!verify_supply_route_key_collisions())
+        return 0;
+
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
     if (!validate_initial_campaign_flow(game))
         return 0;

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -19,5 +19,6 @@ int verify_difficulty_scaling();
 int verify_crafting_and_energy_research();
 int verify_auxiliary_and_escape_protocol();
 int verify_fractional_resource_accumulation();
+int verify_supply_route_key_collisions();
 
 #endif


### PR DESCRIPTION
## Summary
- add a RouteKey helper inside `Game` so supply routes use composite keys
- update convoy lookup logic to work with the new key representation
- add backend tests that cover large planet id supply routes to prevent key collisions

## Testing
- make
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cb1755c8cc8331b3bbaa1d493f577c