### PR TITLE
Handle consecutive convoy raids

### DIFF
--- a/src/game_convoys.cpp
+++ b/src/game_convoys.cpp
@@ -348,12 +348,21 @@ void Game::advance_convoys(double seconds)
             convoy.raid_meter += risk * seconds;
             if (convoy.raid_meter >= 1.0)
             {
-                this->handle_convoy_raid(convoy, origin_under_attack, destination_under_attack);
-                if (convoy.destroyed)
+                while (convoy.raid_meter >= 1.0 && !convoy.destroyed)
                 {
-                    completed.push_back(entries[i].key);
-                    continue;
+                    double remainder = convoy.raid_meter - 1.0;
+                    if (remainder < 0.0)
+                        remainder = 0.0;
+                    this->handle_convoy_raid(convoy, origin_under_attack, destination_under_attack);
+                    if (convoy.destroyed)
+                    {
+                        completed.push_back(entries[i].key);
+                        break;
+                    }
+                    convoy.raid_meter = remainder;
                 }
+                if (convoy.destroyed)
+                    continue;
             }
         }
         convoy.remaining_time -= seconds;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -39,6 +39,8 @@ int main()
         return 0;
     if (!evaluate_ship_upgrade_research(game))
         return 0;
+    if (!verify_multiple_convoy_raids())
+        return 0;
 
 
     if (!compare_energy_pressure_scenarios())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -7,6 +7,7 @@ int verify_backend_roundtrip();
 int validate_initial_campaign_flow(Game &game);
 int evaluate_building_and_convoy_systems(Game &game);
 int evaluate_ship_upgrade_research(Game &game);
+int verify_multiple_convoy_raids();
 int compare_energy_pressure_scenarios();
 int compare_storyline_assaults();
 int analyze_manual_vs_auto_assault_controls();


### PR DESCRIPTION
## Summary
- update convoy advancement to resolve multiple raids when the raid meter accumulates beyond a single threshold
- add a regression test that drives a long convoy tick and asserts multiple raid entries or destruction
- register the new convoy raid test with the scenario header and main test harness

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cb23d5fe448331a4590bc531848cfd