### PR TITLE
Add automated supply contract management

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -20,9 +20,11 @@ Game::Game(const ft_string &host, const ft_string &path, int difficulty)
       _supply_routes(),
       _route_lookup(),
       _active_convoys(),
+      _supply_contracts(),
       _resource_deficits(),
       _next_route_id(1),
-      _next_convoy_id(1)
+      _next_convoy_id(1),
+      _next_contract_id(1)
 {
     ft_sharedptr<ft_planet> terra(new ft_planet_terra());
     ft_sharedptr<ft_planet> mars(new ft_planet_mars());
@@ -150,6 +152,7 @@ void Game::produce(double seconds)
 void Game::tick(double seconds)
 {
     this->produce(seconds);
+    this->process_supply_contracts(seconds);
     this->advance_convoys(seconds);
     this->_buildings.tick(*this, seconds);
     size_t count = this->_fleets.size();

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -39,6 +39,8 @@ int main()
         return 0;
     if (!evaluate_ship_upgrade_research(game))
         return 0;
+    if (!verify_supply_contract_automation())
+        return 0;
     if (!verify_multiple_convoy_raids())
         return 0;
 

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -7,6 +7,7 @@ int verify_backend_roundtrip();
 int validate_initial_campaign_flow(Game &game);
 int evaluate_building_and_convoy_systems(Game &game);
 int evaluate_ship_upgrade_research(Game &game);
+int verify_supply_contract_automation();
 int verify_multiple_convoy_raids();
 int compare_energy_pressure_scenarios();
 int compare_storyline_assaults();


### PR DESCRIPTION
## Summary
- add persistent supply contract records and expose public management APIs
- schedule recurring convoy dispatches with interval timers and partial fulfillment handling
- accelerate resupply after raids and extend tests to cover contract workflows

## Testing
- make test *(fails: libft submodule is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb26be845c83319a6d3a506b297731