### PR TITLE
Track convoy streaks for new quest objectives

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -24,7 +24,13 @@ Game::Game(const ft_string &host, const ft_string &path, int difficulty)
       _resource_deficits(),
       _next_route_id(1),
       _next_convoy_id(1),
-      _next_contract_id(1)
+      _next_contract_id(1),
+      _convoys_delivered_total(0),
+      _convoy_raid_losses(0),
+      _current_delivery_streak(0),
+      _longest_delivery_streak(0),
+      _streak_milestones(),
+      _next_streak_milestone_index(0)
 {
     ft_sharedptr<ft_planet> terra(new ft_planet_terra());
     ft_sharedptr<ft_planet> mars(new ft_planet_mars());
@@ -44,6 +50,9 @@ Game::Game(const ft_string &host, const ft_string &path, int difficulty)
     this->_locked_planets.insert(PLANET_LUNA, luna);
 
     this->configure_difficulty(difficulty);
+    this->_streak_milestones.push_back(3);
+    this->_streak_milestones.push_back(5);
+    this->_streak_milestones.push_back(8);
 }
 
 Game::~Game()

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -109,11 +109,13 @@ private:
         int     destination_escort;
         bool    raided;
         bool    destroyed;
+        bool    loss_recorded;
         ft_supply_convoy()
             : id(0), route_id(0), contract_id(0), origin_planet_id(0),
               destination_planet_id(0), resource_id(0), amount(0),
               remaining_time(0.0), raid_meter(0.0), origin_escort(0),
-              destination_escort(0), raided(false), destroyed(false)
+              destination_escort(0), raided(false), destroyed(false),
+              loss_recorded(false)
         {}
     };
     ft_map<RouteKey, ft_supply_route>            _supply_routes;
@@ -124,6 +126,12 @@ private:
     int                                          _next_route_id;
     int                                          _next_convoy_id;
     int                                          _next_contract_id;
+    int                                          _convoys_delivered_total;
+    int                                          _convoy_raid_losses;
+    int                                          _current_delivery_streak;
+    int                                          _longest_delivery_streak;
+    ft_vector<int>                               _streak_milestones;
+    size_t                                       _next_streak_milestone_index;
 
     ft_sharedptr<ft_planet> get_planet(int id);
     ft_sharedptr<const ft_planet> get_planet(int id) const;
@@ -158,7 +166,7 @@ private:
     double calculate_convoy_travel_time(const ft_supply_route &route, int origin_escort, int destination_escort) const;
     double calculate_convoy_raid_risk(const ft_supply_convoy &convoy, bool origin_under_attack, bool destination_under_attack) const;
     void handle_convoy_raid(ft_supply_convoy &convoy, bool origin_under_attack, bool destination_under_attack);
-    void finalize_convoy(const ft_supply_convoy &convoy);
+    void finalize_convoy(ft_supply_convoy &convoy);
     void handle_contract_completion(const ft_supply_convoy &convoy);
     void accelerate_contract(int contract_id, double fraction);
     bool has_active_convoy_for_contract(int contract_id) const;
@@ -167,6 +175,9 @@ private:
                         int contract_id);
     void process_supply_contracts(double seconds);
     void advance_convoys(double seconds);
+    void record_convoy_delivery(const ft_supply_convoy &convoy);
+    void record_convoy_loss(const ft_supply_convoy &convoy, bool destroyed_by_raid);
+    void reset_delivery_streak();
 
 public:
     Game(const ft_string &host, const ft_string &path, int difficulty = GAME_DIFFICULTY_STANDARD);
@@ -225,6 +236,10 @@ public:
     int get_ore(int planet_id, int ore_id) const;
     void set_ore(int planet_id, int ore_id, int amount);
     int transfer_ore(int from_planet_id, int to_planet_id, int ore_id, int amount);
+    int get_total_convoys_delivered() const { return this->_convoys_delivered_total; }
+    int get_convoy_raid_losses() const { return this->_convoy_raid_losses; }
+    int get_convoy_delivery_streak() const { return this->_current_delivery_streak; }
+    int get_longest_convoy_delivery_streak() const { return this->_longest_delivery_streak; }
     double get_rate(int planet_id, int ore_id) const;
     const ft_vector<Pair<int, double> > &get_planet_resources(int planet_id) const;
     int get_active_convoy_count() const;

--- a/src/game_quests.cpp
+++ b/src/game_quests.cpp
@@ -51,6 +51,9 @@ void Game::build_quest_context(ft_quest_context &context) const
         context.total_ship_count += fleet->get_ship_count();
         context.total_ship_hp += fleet->get_total_ship_hp();
     }
+    context.successful_deliveries = this->_convoys_delivered_total;
+    context.convoy_raid_losses = this->_convoy_raid_losses;
+    context.delivery_streak = this->_current_delivery_streak;
 }
 
 void Game::handle_quest_completion(int quest_id)

--- a/src/quests.cpp
+++ b/src/quests.cpp
@@ -58,6 +58,59 @@ QuestManager::QuestManager()
     investigate->objectives.push_back(objective);
     this->register_quest(investigate);
 
+    ft_sharedptr<ft_quest_definition> secure(new ft_quest_definition());
+    secure->id = QUEST_SECURE_SUPPLY_LINES;
+    secure->name = ft_string("Secure Supply Lines");
+    secure->description = ft_string("Deliver convoys while keeping raid losses contained.");
+    secure->time_limit = 0.0;
+    secure->requires_choice = false;
+    secure->required_choice_quest = 0;
+    secure->required_choice_value = 0;
+    secure->prerequisites.push_back(QUEST_INVESTIGATE_RAIDERS);
+    objective.type = QUEST_OBJECTIVE_CONVOYS_DELIVERED;
+    objective.target_id = 0;
+    objective.amount = 3;
+    secure->objectives.push_back(objective);
+    objective.type = QUEST_OBJECTIVE_CONVOY_RAID_LOSSES_AT_MOST;
+    objective.target_id = 0;
+    objective.amount = 1;
+    secure->objectives.push_back(objective);
+    this->register_quest(secure);
+
+    ft_sharedptr<ft_quest_definition> streak(new ft_quest_definition());
+    streak->id = QUEST_STEADY_SUPPLY_STREAK;
+    streak->name = ft_string("Steady Supply Streak");
+    streak->description = ft_string("Maintain an uninterrupted chain of convoy deliveries.");
+    streak->time_limit = 0.0;
+    streak->requires_choice = false;
+    streak->required_choice_quest = 0;
+    streak->required_choice_value = 0;
+    streak->prerequisites.push_back(QUEST_SECURE_SUPPLY_LINES);
+    objective.type = QUEST_OBJECTIVE_CONVOY_STREAK;
+    objective.target_id = 0;
+    objective.amount = 3;
+    streak->objectives.push_back(objective);
+    this->register_quest(streak);
+
+    ft_sharedptr<ft_quest_definition> escort(new ft_quest_definition());
+    escort->id = QUEST_HIGH_VALUE_ESCORT;
+    escort->name = ft_string("High-Value Escort");
+    escort->description = ft_string("Escort critical shipments through heightened raids.");
+    escort->time_limit = 0.0;
+    escort->requires_choice = false;
+    escort->required_choice_quest = 0;
+    escort->required_choice_value = 0;
+    escort->prerequisites.push_back(QUEST_STEADY_SUPPLY_STREAK);
+    objective.type = QUEST_OBJECTIVE_CONVOYS_DELIVERED;
+    objective.target_id = 0;
+    objective.amount = 8;
+    escort->objectives.push_back(objective);
+    objective.type = QUEST_OBJECTIVE_CONVOY_RAID_LOSSES_AT_MOST;
+    objective.target_id = 0;
+    objective.amount = 1;
+    escort->objectives.push_back(objective);
+    this->register_quest(escort);
+
     ft_sharedptr<ft_quest_definition> battle(new ft_quest_definition());
     battle->id = QUEST_CLIMACTIC_BATTLE;
     battle->name = ft_string("Climactic Battle");
@@ -67,6 +120,7 @@ QuestManager::QuestManager()
     battle->required_choice_quest = 0;
     battle->required_choice_value = 0;
     battle->prerequisites.push_back(QUEST_INVESTIGATE_RAIDERS);
+    battle->prerequisites.push_back(QUEST_HIGH_VALUE_ESCORT);
     objective.type = QUEST_OBJECTIVE_RESEARCH_COMPLETED;
     objective.target_id = RESEARCH_UNLOCK_VULCAN;
     objective.amount = 1;
@@ -242,6 +296,21 @@ bool QuestManager::are_objectives_met(const ft_quest_definition &definition, con
         else if (objective.type == QUEST_OBJECTIVE_TOTAL_SHIP_HP)
         {
             if (context.total_ship_hp < objective.amount)
+                return false;
+        }
+        else if (objective.type == QUEST_OBJECTIVE_CONVOYS_DELIVERED)
+        {
+            if (context.successful_deliveries < objective.amount)
+                return false;
+        }
+        else if (objective.type == QUEST_OBJECTIVE_CONVOY_STREAK)
+        {
+            if (context.delivery_streak < objective.amount)
+                return false;
+        }
+        else if (objective.type == QUEST_OBJECTIVE_CONVOY_RAID_LOSSES_AT_MOST)
+        {
+            if (context.convoy_raid_losses > objective.amount)
                 return false;
         }
     }

--- a/src/quests.hpp
+++ b/src/quests.hpp
@@ -18,7 +18,10 @@ enum e_quest_id
     QUEST_CLIMACTIC_BATTLE,
     QUEST_CRITICAL_DECISION,
     QUEST_ORDER_UPRISING,
-    QUEST_REBELLION_FLEET
+    QUEST_REBELLION_FLEET,
+    QUEST_SECURE_SUPPLY_LINES,
+    QUEST_STEADY_SUPPLY_STREAK,
+    QUEST_HIGH_VALUE_ESCORT
 };
 
 enum e_quest_status
@@ -36,7 +39,10 @@ enum e_quest_objective_type
     QUEST_OBJECTIVE_RESOURCE_TOTAL = 1,
     QUEST_OBJECTIVE_RESEARCH_COMPLETED,
     QUEST_OBJECTIVE_FLEET_COUNT,
-    QUEST_OBJECTIVE_TOTAL_SHIP_HP
+    QUEST_OBJECTIVE_TOTAL_SHIP_HP,
+    QUEST_OBJECTIVE_CONVOYS_DELIVERED,
+    QUEST_OBJECTIVE_CONVOY_STREAK,
+    QUEST_OBJECTIVE_CONVOY_RAID_LOSSES_AT_MOST
 };
 
 enum e_quest_choice_value
@@ -92,7 +98,13 @@ struct ft_quest_context
     ft_map<int, int> research_status;
     int total_ship_count;
     int total_ship_hp;
-    ft_quest_context() : resource_totals(), research_status(), total_ship_count(0), total_ship_hp(0) {}
+    int successful_deliveries;
+    int convoy_raid_losses;
+    int delivery_streak;
+    ft_quest_context()
+        : resource_totals(), research_status(), total_ship_count(0), total_ship_hp(0),
+          successful_deliveries(0), convoy_raid_losses(0), delivery_streak(0)
+    {}
 };
 
 class QuestManager

--- a/tests/game_test_energy.cpp
+++ b/tests/game_test_energy.cpp
@@ -3,6 +3,7 @@
 #include "../libft/Template/vector.hpp"
 #include "fleets.hpp"
 #include "buildings.hpp"
+#include "quests.hpp"
 #include "game_test_scenarios.hpp"
 
 int compare_energy_pressure_scenarios()
@@ -167,6 +168,23 @@ int compare_storyline_assaults()
     FT_ASSERT(narrative_game.start_research(RESEARCH_UNLOCK_ZALTHOR));
     narrative_game.tick(40.0);
     narrative_game.tick(0.0);
+    FT_ASSERT_EQ(QUEST_SECURE_SUPPLY_LINES, narrative_game.get_active_quest());
+    narrative_game.ensure_planet_item_slot(PLANET_MARS, ITEM_IRON_BAR);
+    narrative_game.set_ore(PLANET_MARS, ITEM_IRON_BAR, 0);
+    narrative_game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 200);
+    for (int convoy = 0; convoy < 8; ++convoy)
+    {
+        int moved = narrative_game.transfer_ore(PLANET_TERRA, PLANET_MARS, ITEM_IRON_BAR, 20);
+        FT_ASSERT(moved >= 20);
+        double waited = 0.0;
+        while (narrative_game.get_active_convoy_count() > 0 && waited < 240.0)
+        {
+            narrative_game.tick(4.0);
+            waited += 4.0;
+        }
+        FT_ASSERT(waited < 240.0);
+    }
+    FT_ASSERT_EQ(QUEST_STATUS_COMPLETED, narrative_game.get_quest_status(QUEST_HIGH_VALUE_ESCORT));
     FT_ASSERT_EQ(QUEST_CLIMACTIC_BATTLE, narrative_game.get_active_quest());
     narrative_game.remove_ship(1, narrative_setup_one);
     narrative_game.remove_ship(2, narrative_setup_two);

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -40,6 +40,8 @@ int main()
         return 0;
     if (!evaluate_building_and_convoy_systems(game))
         return 0;
+    if (!verify_convoy_quest_objectives())
+        return 0;
     if (!evaluate_ship_upgrade_research(game))
         return 0;
     if (!verify_supply_contract_automation())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -8,6 +8,7 @@ int validate_initial_campaign_flow(Game &game);
 int evaluate_building_and_convoy_systems(Game &game);
 int evaluate_ship_upgrade_research(Game &game);
 int verify_supply_contract_automation();
+int verify_convoy_quest_objectives();
 int verify_multiple_convoy_raids();
 int compare_energy_pressure_scenarios();
 int compare_storyline_assaults();


### PR DESCRIPTION
## Summary
- track convoy delivery totals, streaks, and raid losses in Game and expose them through the quest context
- introduce convoy-focused objective types and questlines with lore feedback for streak milestones and breaks
- expand campaign and energy storyline tests plus a dedicated scenario to cover success and failure of the new objectives

## Testing
- make test *(fails: libft target `Full_Libft.a` is not available in the bundled libft build scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9441029083318074e74ecb99c4d4