### PR TITLE
Allow supply contracts to launch multiple concurrent convoys

### DIFF
--- a/src/game.hpp
+++ b/src/game.hpp
@@ -31,12 +31,13 @@ public:
         double  elapsed_seconds;
         bool    has_minimum_stock;
         int     minimum_stock;
+        int     max_active_convoys;
 
         ft_supply_contract()
             : id(0), origin_planet_id(0), destination_planet_id(0),
               resource_id(0), shipment_size(0), interval_seconds(0.0),
               elapsed_seconds(0.0), has_minimum_stock(false),
-              minimum_stock(0)
+              minimum_stock(0), max_active_convoys(1)
         {}
     };
 
@@ -169,6 +170,7 @@ private:
     void finalize_convoy(ft_supply_convoy &convoy);
     void handle_contract_completion(const ft_supply_convoy &convoy);
     void accelerate_contract(int contract_id, double fraction);
+    int count_active_convoys_for_contract(int contract_id) const;
     bool has_active_convoy_for_contract(int contract_id) const;
     int dispatch_convoy(const ft_supply_route &route, int origin_planet_id,
                         int destination_planet_id, int resource_id, int amount,
@@ -247,11 +249,13 @@ public:
     int create_supply_contract(int origin_planet_id, int destination_planet_id,
                                int resource_id, int shipment_size,
                                double interval_seconds,
-                               int minimum_destination_stock = -1);
+                               int minimum_destination_stock = -1,
+                               int max_active_convoys = 1);
     bool cancel_supply_contract(int contract_id);
     bool update_supply_contract(int contract_id, int shipment_size,
                                 double interval_seconds,
-                                int minimum_destination_stock = -1);
+                                int minimum_destination_stock = -1,
+                                int max_active_convoys = -1);
     void get_supply_contract_ids(ft_vector<int> &out) const;
     bool get_supply_contract(int contract_id, ft_supply_contract &out) const;
 

--- a/tests/game_test_campaign.cpp
+++ b/tests/game_test_campaign.cpp
@@ -727,7 +727,7 @@ int verify_supply_contract_automation()
     FT_ASSERT_EQ(0, invalid_contract);
 
     int contract_id = contract_game.create_supply_contract(PLANET_TERRA, PLANET_MARS,
-                                                           ITEM_IRON_BAR, 30, 45.0, 25);
+                                                           ITEM_IRON_BAR, 30, 45.0, 25, 2);
     FT_ASSERT(contract_id > 0);
 
     ft_vector<int> contract_ids;
@@ -748,6 +748,7 @@ int verify_supply_contract_automation()
     FT_ASSERT(contract_details.has_minimum_stock);
     FT_ASSERT_EQ(25, contract_details.minimum_stock);
     FT_ASSERT_EQ(30, contract_details.shipment_size);
+    FT_ASSERT_EQ(2, contract_details.max_active_convoys);
 
     contract_game.tick(30.0);
     FT_ASSERT_EQ(0, contract_game.get_active_convoy_count());
@@ -757,12 +758,13 @@ int verify_supply_contract_automation()
 
     contract_game.tick(120.0);
     FT_ASSERT_EQ(0, contract_game.get_active_convoy_count());
-    FT_ASSERT(contract_game.get_ore(PLANET_MARS, ITEM_IRON_BAR) >= 40);
+    FT_ASSERT(contract_game.get_ore(PLANET_MARS, ITEM_IRON_BAR) >= 70);
 
-    FT_ASSERT(contract_game.update_supply_contract(contract_id, 18, 30.0, -1));
+    FT_ASSERT(contract_game.update_supply_contract(contract_id, 18, 30.0, -1, 3));
     FT_ASSERT(contract_game.get_supply_contract(contract_id, contract_details));
     FT_ASSERT(!contract_details.has_minimum_stock);
     FT_ASSERT_EQ(18, contract_details.shipment_size);
+    FT_ASSERT_EQ(3, contract_details.max_active_convoys);
 
     contract_game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 5);
     contract_game.set_ore(PLANET_MARS, ITEM_IRON_BAR, 12);
@@ -772,6 +774,13 @@ int verify_supply_contract_automation()
 
     contract_game.tick(120.0);
     FT_ASSERT(contract_game.get_ore(PLANET_MARS, ITEM_IRON_BAR) >= 17);
+
+    contract_game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 90);
+    contract_game.set_ore(PLANET_MARS, ITEM_IRON_BAR, 0);
+
+    contract_game.tick(90.0);
+    FT_ASSERT_EQ(0, contract_game.get_active_convoy_count());
+    FT_ASSERT(contract_game.get_ore(PLANET_MARS, ITEM_IRON_BAR) >= 54);
 
     FT_ASSERT(contract_game.cancel_supply_contract(contract_id));
     contract_game.get_supply_contract_ids(contract_ids);


### PR DESCRIPTION
## Summary
- add a configurable max_active_convoys field to supply contracts that defaults to one
- count active convoys per contract and keep dispatching new ones until the contract limit or resources are exhausted
- extend the campaign automation test to cover multi-convoy dispatch and persistence of the new limit

## Testing
- make test *(fails: libft/Full_Libft.a target missing)*


------
https://chatgpt.com/codex/tasks/task_e_68cb9eb682f483318bef5ab141272641