### PR TITLE
Add supply route threat tracking and quest context data

### DIFF
--- a/src/game.hpp
+++ b/src/game.hpp
@@ -90,9 +90,12 @@ private:
         double  base_travel_time;
         int     escort_requirement;
         double  base_raid_risk;
+        double  threat_level;
+        double  quiet_timer;
         ft_supply_route()
             : id(0), origin_planet_id(0), destination_planet_id(0),
-              base_travel_time(30.0), escort_requirement(0), base_raid_risk(0.02)
+              base_travel_time(30.0), escort_requirement(0), base_raid_risk(0.02),
+              threat_level(0.0), quiet_timer(0.0)
         {}
     };
     struct ft_supply_convoy
@@ -164,6 +167,7 @@ private:
     ft_supply_route *find_supply_route(int origin, int destination);
     const ft_supply_route *find_supply_route(int origin, int destination) const;
     const ft_supply_route *get_route_by_id(int route_id) const;
+    ft_supply_route *get_route_by_id(int route_id);
     double estimate_route_travel_time(int origin, int destination) const;
     int estimate_route_escort_requirement(int origin, int destination) const;
     double estimate_route_raid_risk(int origin, int destination) const;
@@ -187,6 +191,9 @@ private:
     void record_convoy_delivery(const ft_supply_convoy &convoy);
     void record_convoy_loss(const ft_supply_convoy &convoy, bool destroyed_by_raid);
     void reset_delivery_streak();
+    void modify_route_threat(ft_supply_route &route, double delta, bool reset_quiet_timer);
+    void decay_route_threat(ft_supply_route &route, double seconds);
+    void decay_all_route_threat(double seconds);
 
 public:
     Game(const ft_string &host, const ft_string &path, int difficulty = GAME_DIFFICULTY_STANDARD);
@@ -253,6 +260,7 @@ public:
     int get_convoy_raid_losses() const { return this->_convoy_raid_losses; }
     int get_convoy_delivery_streak() const { return this->_current_delivery_streak; }
     int get_longest_convoy_delivery_streak() const { return this->_longest_delivery_streak; }
+    double get_supply_route_threat_level(int origin_planet_id, int destination_planet_id) const;
     double get_rate(int planet_id, int ore_id) const;
     const ft_vector<Pair<int, double> > &get_planet_resources(int planet_id) const;
     int get_active_convoy_count() const;

--- a/src/game_quests.cpp
+++ b/src/game_quests.cpp
@@ -54,6 +54,27 @@ void Game::build_quest_context(ft_quest_context &context) const
     context.successful_deliveries = this->_convoys_delivered_total;
     context.convoy_raid_losses = this->_convoy_raid_losses;
     context.delivery_streak = this->_current_delivery_streak;
+    double total_threat = 0.0;
+    double max_threat = 0.0;
+    size_t route_count = this->_supply_routes.size();
+    if (route_count > 0)
+    {
+        const Pair<RouteKey, ft_supply_route> *route_entries = this->_supply_routes.end();
+        route_entries -= route_count;
+        for (size_t i = 0; i < route_count; ++i)
+        {
+            double threat = route_entries[i].value.threat_level;
+            total_threat += threat;
+            if (threat > max_threat)
+                max_threat = threat;
+        }
+    }
+    context.total_convoy_threat = total_threat;
+    if (route_count > 0)
+        context.average_convoy_threat = total_threat / static_cast<double>(route_count);
+    else
+        context.average_convoy_threat = 0.0;
+    context.maximum_convoy_threat = max_threat;
 }
 
 void Game::handle_quest_completion(int quest_id)

--- a/src/quests.hpp
+++ b/src/quests.hpp
@@ -101,9 +101,13 @@ struct ft_quest_context
     int successful_deliveries;
     int convoy_raid_losses;
     int delivery_streak;
+    double total_convoy_threat;
+    double average_convoy_threat;
+    double maximum_convoy_threat;
     ft_quest_context()
         : resource_totals(), research_status(), total_ship_count(0), total_ship_hp(0),
-          successful_deliveries(0), convoy_raid_losses(0), delivery_streak(0)
+          successful_deliveries(0), convoy_raid_losses(0), delivery_streak(0),
+          total_convoy_threat(0.0), average_convoy_threat(0.0), maximum_convoy_threat(0.0)
     {}
 };
 

--- a/test_failures.log
+++ b/test_failures.log
@@ -1,3 +1,3 @@
 # Test failure log
 # Outstanding failures:
-# (none)
+# 2025-09-18: `make test` fails because `libft/Full_Libft.a` target is unavailable in the provided environment.

--- a/tests/game_test_campaign.cpp
+++ b/tests/game_test_campaign.cpp
@@ -910,6 +910,9 @@ int verify_multiple_convoy_raids()
 
     convoy_game.tick(300.0);
 
+    double threat_after_raids = convoy_game.get_supply_route_threat_level(PLANET_TERRA, PLANET_NOCTARIS_PRIME);
+    FT_ASSERT(threat_after_raids > 0.1);
+
     const ft_vector<ft_string> &log = convoy_game.get_lore_log();
     size_t raid_entries = 0;
     bool destroyed_recorded = false;
@@ -922,5 +925,21 @@ int verify_multiple_convoy_raids()
             destroyed_recorded = true;
     }
     FT_ASSERT(raid_entries >= 2 || destroyed_recorded);
+    int deliveries_before = convoy_game.get_total_convoys_delivered();
+    for (int convoy = 0; convoy < 3; ++convoy)
+    {
+        int moved_again = convoy_game.transfer_ore(PLANET_TERRA, PLANET_NOCTARIS_PRIME, ITEM_IRON_BAR, 20);
+        FT_ASSERT(moved_again >= 20);
+        double wait = 0.0;
+        while (convoy_game.get_active_convoy_count() > 0 && wait < 360.0)
+        {
+            convoy_game.tick(4.0);
+            wait += 4.0;
+        }
+        FT_ASSERT(wait < 360.0);
+    }
+    FT_ASSERT(convoy_game.get_total_convoys_delivered() > deliveries_before);
+    double threat_after_deliveries = convoy_game.get_supply_route_threat_level(PLANET_TERRA, PLANET_NOCTARIS_PRIME);
+    FT_ASSERT(threat_after_deliveries < threat_after_raids);
     return 1;
 }


### PR DESCRIPTION
## Summary
- add threat bookkeeping fields to supply routes, adjust convoy handling to modify threat, and add decay plus a getter for UI use
- incorporate threat aggregates into the quest context for future quest logic
- extend campaign convoy raid test to validate threat escalation and reduction behaviour and note missing libft test dependency in the log

## Testing
- `make test` *(fails: libft/Full_Libft.a target is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba6674c088331ac123a1434bc6289