### PR TITLE
Add branch quest chains with scripted assaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ TEST_DIR    = tests
 
 SRC_COMMON  = \
     $(SRC_DIR)/backend_client.cpp \
+    $(SRC_DIR)/achievements.cpp \
     $(SRC_DIR)/planets.cpp \
     $(SRC_DIR)/fleets.cpp \
     $(SRC_DIR)/buildings.cpp \
@@ -33,6 +34,7 @@ SRC_MAIN    = $(SRC_DIR)/main.cpp
 SRC         = $(SRC_COMMON) $(SRC_MAIN)
 SRC_TEST    = $(SRC_COMMON) \
     $(TEST_DIR)/game_test_main.cpp \
+    $(TEST_DIR)/game_test_achievements.cpp \
     $(TEST_DIR)/game_test_backend.cpp \
     $(TEST_DIR)/game_test_campaign.cpp \
     $(TEST_DIR)/game_test_energy.cpp \

--- a/src/achievements.cpp
+++ b/src/achievements.cpp
@@ -1,0 +1,284 @@
+#include "achievements.hpp"
+#include "../libft/Template/move.hpp"
+
+AchievementManager::AchievementManager()
+{
+    ft_sharedptr<ft_achievement_definition> second_home(new ft_achievement_definition());
+    second_home->id = ACHIEVEMENT_SECOND_HOME;
+    second_home->name = ft_string("Second Home");
+    second_home->description = ft_string("Unlock an additional colony world.");
+    second_home->event_id = ACHIEVEMENT_EVENT_PLANET_UNLOCKED;
+    second_home->target_value = 1;
+    second_home->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(second_home);
+
+    ft_sharedptr<ft_achievement_definition> pioneer(new ft_achievement_definition());
+    pioneer->id = ACHIEVEMENT_RESEARCH_PIONEER;
+    pioneer->name = ft_string("Research Pioneer");
+    pioneer->description = ft_string("Complete three major research projects.");
+    pioneer->event_id = ACHIEVEMENT_EVENT_RESEARCH_COMPLETED;
+    pioneer->target_value = 3;
+    pioneer->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(pioneer);
+
+    ft_sharedptr<ft_achievement_definition> pilot(new ft_achievement_definition());
+    pilot->id = ACHIEVEMENT_LOGISTICS_PILOT;
+    pilot->name = ft_string("Logistics Pilot");
+    pilot->description = ft_string("Deliver three convoys successfully.");
+    pilot->event_id = ACHIEVEMENT_EVENT_CONVOY_DELIVERED;
+    pilot->target_value = 3;
+    pilot->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(pilot);
+
+    ft_sharedptr<ft_achievement_definition> guardian(new ft_achievement_definition());
+    guardian->id = ACHIEVEMENT_CONVOY_STREAK_GUARDIAN;
+    guardian->name = ft_string("Streak Guardian");
+    guardian->description = ft_string("Maintain a five convoy success streak.");
+    guardian->event_id = ACHIEVEMENT_EVENT_CONVOY_STREAK_BEST;
+    guardian->target_value = 5;
+    guardian->progress_mode = ACHIEVEMENT_PROGRESS_BEST_VALUE;
+    this->register_achievement(guardian);
+
+    ft_sharedptr<ft_achievement_definition> skirmish(new ft_achievement_definition());
+    skirmish->id = ACHIEVEMENT_QUEST_INITIAL_SKIRMISHES;
+    skirmish->name = ft_string("Perimeter Guardian");
+    skirmish->description = ft_string("Complete the Initial Raider Skirmishes quest.");
+    skirmish->event_id = ACHIEVEMENT_EVENT_QUEST_INITIAL_SKIRMISHES;
+    skirmish->target_value = 1;
+    skirmish->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(skirmish);
+
+    ft_sharedptr<ft_achievement_definition> defense(new ft_achievement_definition());
+    defense->id = ACHIEVEMENT_QUEST_DEFENSE_OF_TERRA;
+    defense->name = ft_string("Terra's Shield");
+    defense->description = ft_string("Complete the Defense of Terra quest.");
+    defense->event_id = ACHIEVEMENT_EVENT_QUEST_DEFENSE_OF_TERRA;
+    defense->target_value = 1;
+    defense->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(defense);
+
+    ft_sharedptr<ft_achievement_definition> investigate(new ft_achievement_definition());
+    investigate->id = ACHIEVEMENT_QUEST_INVESTIGATE_RAIDERS;
+    investigate->name = ft_string("Cipher Breaker");
+    investigate->description = ft_string("Complete the Investigate Raider Motives quest.");
+    investigate->event_id = ACHIEVEMENT_EVENT_QUEST_INVESTIGATE_RAIDERS;
+    investigate->target_value = 1;
+    investigate->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(investigate);
+
+    ft_sharedptr<ft_achievement_definition> supply(new ft_achievement_definition());
+    supply->id = ACHIEVEMENT_QUEST_SECURE_SUPPLY_LINES;
+    supply->name = ft_string("Supply Line Sentinel");
+    supply->description = ft_string("Complete the Secure Supply Lines quest.");
+    supply->event_id = ACHIEVEMENT_EVENT_QUEST_SECURE_SUPPLY_LINES;
+    supply->target_value = 1;
+    supply->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(supply);
+
+    ft_sharedptr<ft_achievement_definition> streak(new ft_achievement_definition());
+    streak->id = ACHIEVEMENT_QUEST_STEADY_SUPPLY_STREAK;
+    streak->name = ft_string("Streak Specialist");
+    streak->description = ft_string("Complete the Steady Supply Streak quest.");
+    streak->event_id = ACHIEVEMENT_EVENT_QUEST_STEADY_SUPPLY_STREAK;
+    streak->target_value = 1;
+    streak->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(streak);
+
+    ft_sharedptr<ft_achievement_definition> escort(new ft_achievement_definition());
+    escort->id = ACHIEVEMENT_QUEST_HIGH_VALUE_ESCORT;
+    escort->name = ft_string("Escort Commander");
+    escort->description = ft_string("Complete the High-Value Escort quest.");
+    escort->event_id = ACHIEVEMENT_EVENT_QUEST_HIGH_VALUE_ESCORT;
+    escort->target_value = 1;
+    escort->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(escort);
+
+    ft_sharedptr<ft_achievement_definition> battle(new ft_achievement_definition());
+    battle->id = ACHIEVEMENT_QUEST_CLIMACTIC_BATTLE;
+    battle->name = ft_string("Climactic Victor");
+    battle->description = ft_string("Complete the Climactic Battle quest.");
+    battle->event_id = ACHIEVEMENT_EVENT_QUEST_CLIMACTIC_BATTLE;
+    battle->target_value = 1;
+    battle->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(battle);
+
+    ft_sharedptr<ft_achievement_definition> decision(new ft_achievement_definition());
+    decision->id = ACHIEVEMENT_QUEST_CRITICAL_DECISION;
+    decision->name = ft_string("Decisive Arbiter");
+    decision->description = ft_string("Resolve The Critical Decision quest.");
+    decision->event_id = ACHIEVEMENT_EVENT_QUEST_CRITICAL_DECISION;
+    decision->target_value = 1;
+    decision->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(decision);
+
+    ft_sharedptr<ft_achievement_definition> order(new ft_achievement_definition());
+    order->id = ACHIEVEMENT_QUEST_ORDER_UPRISING;
+    order->name = ft_string("Order's Hammer");
+    order->description = ft_string("Complete the Order's Last Stand quest.");
+    order->event_id = ACHIEVEMENT_EVENT_QUEST_ORDER_UPRISING;
+    order->target_value = 1;
+    order->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(order);
+
+    ft_sharedptr<ft_achievement_definition> rebellion(new ft_achievement_definition());
+    rebellion->id = ACHIEVEMENT_QUEST_REBELLION_FLEET;
+    rebellion->name = ft_string("Rebellion's Hope");
+    rebellion->description = ft_string("Complete the Rebellion Rising quest.");
+    rebellion->event_id = ACHIEVEMENT_EVENT_QUEST_REBELLION_FLEET;
+    rebellion->target_value = 1;
+    rebellion->progress_mode = ACHIEVEMENT_PROGRESS_INCREMENTAL;
+    this->register_achievement(rebellion);
+}
+
+void AchievementManager::register_achievement(const ft_sharedptr<ft_achievement_definition> &definition)
+{
+    if (!definition)
+        return ;
+    this->_definitions.insert(definition->id, definition);
+    ft_achievement_progress progress;
+    this->_progress.insert(definition->id, progress);
+    Pair<int, ft_vector<int> > *index_entry = this->_event_index.find(definition->event_id);
+    if (index_entry == ft_nullptr)
+    {
+        ft_vector<int> ids;
+        this->_event_index.insert(definition->event_id, ft_move(ids));
+        index_entry = this->_event_index.find(definition->event_id);
+    }
+    if (index_entry != ft_nullptr)
+        index_entry->value.push_back(definition->id);
+}
+
+ft_achievement_progress &AchievementManager::ensure_progress(int achievement_id)
+{
+    Pair<int, ft_achievement_progress> *entry = this->_progress.find(achievement_id);
+    if (entry == ft_nullptr)
+    {
+        ft_achievement_progress progress;
+        this->_progress.insert(achievement_id, progress);
+        entry = this->_progress.find(achievement_id);
+    }
+    return entry->value;
+}
+
+const ft_achievement_progress *AchievementManager::find_progress(int achievement_id) const
+{
+    const Pair<int, ft_achievement_progress> *entry = this->_progress.find(achievement_id);
+    if (entry == ft_nullptr)
+        return ft_nullptr;
+    return &entry->value;
+}
+
+void AchievementManager::record_event(int event_id, int value, ft_vector<int> *completed)
+{
+    Pair<int, ft_vector<int> > *index_entry = this->_event_index.find(event_id);
+    if (index_entry == ft_nullptr)
+        return ;
+    if (value < 0)
+        value = 0;
+    ft_vector<int> &achievement_ids = index_entry->value;
+    for (size_t i = 0; i < achievement_ids.size(); ++i)
+    {
+        int achievement_id = achievement_ids[i];
+        Pair<int, ft_sharedptr<ft_achievement_definition> > *definition_entry = this->_definitions.find(achievement_id);
+        if (definition_entry == ft_nullptr)
+            continue;
+        const ft_sharedptr<ft_achievement_definition> &definition = definition_entry->value;
+        ft_achievement_progress &progress = this->ensure_progress(achievement_id);
+        if (progress.completed)
+            continue;
+        if (definition->progress_mode == ACHIEVEMENT_PROGRESS_INCREMENTAL)
+        {
+            progress.value += value;
+        }
+        else if (definition->progress_mode == ACHIEVEMENT_PROGRESS_BEST_VALUE)
+        {
+            if (value > progress.value)
+                progress.value = value;
+        }
+        if (!progress.completed && progress.value >= definition->target_value)
+        {
+            progress.completed = true;
+            if (completed != ft_nullptr)
+                completed->push_back(achievement_id);
+        }
+    }
+}
+
+void AchievementManager::record_event(int event_id, int value)
+{
+    this->record_event(event_id, value, ft_nullptr);
+}
+
+bool AchievementManager::is_completed(int achievement_id) const
+{
+    return this->get_status(achievement_id) == ACHIEVEMENT_STATUS_COMPLETED;
+}
+
+int AchievementManager::get_status(int achievement_id) const
+{
+    const ft_achievement_progress *progress = this->find_progress(achievement_id);
+    if (progress == ft_nullptr)
+        return ACHIEVEMENT_STATUS_LOCKED;
+    if (progress->completed)
+        return ACHIEVEMENT_STATUS_COMPLETED;
+    if (progress->value > 0)
+        return ACHIEVEMENT_STATUS_IN_PROGRESS;
+    return ACHIEVEMENT_STATUS_LOCKED;
+}
+
+int AchievementManager::get_progress(int achievement_id) const
+{
+    const ft_achievement_progress *progress = this->find_progress(achievement_id);
+    if (progress == ft_nullptr)
+        return 0;
+    return progress->value;
+}
+
+int AchievementManager::get_target(int achievement_id) const
+{
+    const Pair<int, ft_sharedptr<ft_achievement_definition> > *entry = this->_definitions.find(achievement_id);
+    if (entry == ft_nullptr)
+        return 0;
+    const ft_sharedptr<ft_achievement_definition> &definition = entry->value;
+    if (!definition)
+        return 0;
+    return definition->target_value;
+}
+
+bool AchievementManager::get_info(int achievement_id, ft_achievement_info &out) const
+{
+    const Pair<int, ft_sharedptr<ft_achievement_definition> > *entry = this->_definitions.find(achievement_id);
+    if (entry == ft_nullptr)
+        return false;
+    const ft_sharedptr<ft_achievement_definition> &definition = entry->value;
+    if (!definition)
+        return false;
+    out.id = definition->id;
+    out.name = definition->name;
+    out.description = definition->description;
+    out.target = definition->target_value;
+    out.progress = 0;
+    out.status = ACHIEVEMENT_STATUS_LOCKED;
+    const ft_achievement_progress *progress = this->find_progress(achievement_id);
+    if (progress != ft_nullptr)
+    {
+        out.progress = progress->value;
+        if (progress->completed)
+            out.status = ACHIEVEMENT_STATUS_COMPLETED;
+        else if (progress->value > 0)
+            out.status = ACHIEVEMENT_STATUS_IN_PROGRESS;
+    }
+    return true;
+}
+
+void AchievementManager::get_achievement_ids(ft_vector<int> &out) const
+{
+    out.clear();
+    size_t count = this->_definitions.size();
+    if (count == 0)
+        return ;
+    const Pair<int, ft_sharedptr<ft_achievement_definition> > *entries = this->_definitions.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+        out.push_back(entries[i].key);
+}

--- a/src/achievements.hpp
+++ b/src/achievements.hpp
@@ -1,0 +1,112 @@
+#ifndef ACHIEVEMENTS_HPP
+#define ACHIEVEMENTS_HPP
+
+#include "../libft/Libft/libft.hpp"
+#include "../libft/Template/map.hpp"
+#include "../libft/Template/vector.hpp"
+#include "../libft/Template/shared_ptr.hpp"
+#include "../libft/Template/pair.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+enum e_achievement_id
+{
+    ACHIEVEMENT_SECOND_HOME = 1,
+    ACHIEVEMENT_RESEARCH_PIONEER,
+    ACHIEVEMENT_LOGISTICS_PILOT,
+    ACHIEVEMENT_CONVOY_STREAK_GUARDIAN,
+    ACHIEVEMENT_QUEST_INITIAL_SKIRMISHES,
+    ACHIEVEMENT_QUEST_DEFENSE_OF_TERRA,
+    ACHIEVEMENT_QUEST_INVESTIGATE_RAIDERS,
+    ACHIEVEMENT_QUEST_SECURE_SUPPLY_LINES,
+    ACHIEVEMENT_QUEST_STEADY_SUPPLY_STREAK,
+    ACHIEVEMENT_QUEST_HIGH_VALUE_ESCORT,
+    ACHIEVEMENT_QUEST_CLIMACTIC_BATTLE,
+    ACHIEVEMENT_QUEST_CRITICAL_DECISION,
+    ACHIEVEMENT_QUEST_ORDER_UPRISING,
+    ACHIEVEMENT_QUEST_REBELLION_FLEET
+};
+
+enum e_achievement_status
+{
+    ACHIEVEMENT_STATUS_LOCKED = 0,
+    ACHIEVEMENT_STATUS_IN_PROGRESS,
+    ACHIEVEMENT_STATUS_COMPLETED
+};
+
+enum e_achievement_event
+{
+    ACHIEVEMENT_EVENT_PLANET_UNLOCKED = 1,
+    ACHIEVEMENT_EVENT_RESEARCH_COMPLETED,
+    ACHIEVEMENT_EVENT_CONVOY_DELIVERED,
+    ACHIEVEMENT_EVENT_CONVOY_STREAK_BEST,
+    ACHIEVEMENT_EVENT_QUEST_INITIAL_SKIRMISHES,
+    ACHIEVEMENT_EVENT_QUEST_DEFENSE_OF_TERRA,
+    ACHIEVEMENT_EVENT_QUEST_INVESTIGATE_RAIDERS,
+    ACHIEVEMENT_EVENT_QUEST_SECURE_SUPPLY_LINES,
+    ACHIEVEMENT_EVENT_QUEST_STEADY_SUPPLY_STREAK,
+    ACHIEVEMENT_EVENT_QUEST_HIGH_VALUE_ESCORT,
+    ACHIEVEMENT_EVENT_QUEST_CLIMACTIC_BATTLE,
+    ACHIEVEMENT_EVENT_QUEST_CRITICAL_DECISION,
+    ACHIEVEMENT_EVENT_QUEST_ORDER_UPRISING,
+    ACHIEVEMENT_EVENT_QUEST_REBELLION_FLEET
+};
+
+enum e_achievement_progress_mode
+{
+    ACHIEVEMENT_PROGRESS_INCREMENTAL = 1,
+    ACHIEVEMENT_PROGRESS_BEST_VALUE
+};
+
+struct ft_achievement_definition
+{
+    int         id;
+    ft_string   name;
+    ft_string   description;
+    int         event_id;
+    int         target_value;
+    int         progress_mode;
+};
+
+struct ft_achievement_progress
+{
+    int     value;
+    bool    completed;
+    ft_achievement_progress() : value(0), completed(false) {}
+};
+
+struct ft_achievement_info
+{
+    int         id;
+    ft_string   name;
+    ft_string   description;
+    int         status;
+    int         progress;
+    int         target;
+};
+
+class AchievementManager
+{
+private:
+    ft_map<int, ft_sharedptr<ft_achievement_definition> > _definitions;
+    ft_map<int, ft_achievement_progress>                  _progress;
+    ft_map<int, ft_vector<int> >                          _event_index;
+
+    void register_achievement(const ft_sharedptr<ft_achievement_definition> &definition);
+    ft_achievement_progress &ensure_progress(int achievement_id);
+    const ft_achievement_progress *find_progress(int achievement_id) const;
+
+public:
+    AchievementManager();
+
+    void record_event(int event_id, int value, ft_vector<int> *completed);
+    void record_event(int event_id, int value);
+
+    bool is_completed(int achievement_id) const;
+    int get_status(int achievement_id) const;
+    int get_progress(int achievement_id) const;
+    int get_target(int achievement_id) const;
+    bool get_info(int achievement_id, ft_achievement_info &out) const;
+    void get_achievement_ids(ft_vector<int> &out) const;
+};
+
+#endif

--- a/src/fleets.cpp
+++ b/src/fleets.cpp
@@ -202,16 +202,21 @@ namespace
         ship.low_hp_behavior = profile.low_hp_behavior;
         ship.role = profile.role;
     }
+
+    const double ESCORT_VETERANCY_PER_BONUS = 60.0;
+    const int    ESCORT_VETERANCY_MAX_BONUS = 8;
+    const double ESCORT_VETERANCY_MAX_XP =
+        ESCORT_VETERANCY_PER_BONUS * static_cast<double>(ESCORT_VETERANCY_MAX_BONUS);
 }
 
 int ft_fleet::_next_ship_id = 1;
 
-ft_fleet::ft_fleet() noexcept : _id(0), _travel_time(0)
+ft_fleet::ft_fleet() noexcept : _id(0), _travel_time(0), _escort_veterancy(0.0)
 {
     return ;
 }
 
-ft_fleet::ft_fleet(int id) noexcept : _id(id), _travel_time(0)
+ft_fleet::ft_fleet(int id) noexcept : _id(id), _travel_time(0), _escort_veterancy(0.0)
 {
     return ;
 }
@@ -335,6 +340,52 @@ double ft_fleet::get_attack_power() const noexcept
         total += base * efficiency;
     }
     return total;
+}
+
+double ft_fleet::get_escort_veterancy() const noexcept
+{
+    if (this->_escort_veterancy < 0.0)
+        return 0.0;
+    return this->_escort_veterancy;
+}
+
+int ft_fleet::get_escort_veterancy_bonus() const noexcept
+{
+    if (this->_escort_veterancy <= 0.0)
+        return 0;
+    double xp = this->_escort_veterancy;
+    if (xp > ESCORT_VETERANCY_MAX_XP)
+        xp = ESCORT_VETERANCY_MAX_XP;
+    int bonus = static_cast<int>(xp / ESCORT_VETERANCY_PER_BONUS);
+    if (bonus < 0)
+        bonus = 0;
+    if (bonus > ESCORT_VETERANCY_MAX_BONUS)
+        bonus = ESCORT_VETERANCY_MAX_BONUS;
+    return bonus;
+}
+
+bool ft_fleet::add_escort_veterancy(double amount) noexcept
+{
+    if (amount <= 0.0)
+        return false;
+    int before = this->get_escort_veterancy_bonus();
+    this->_escort_veterancy += amount;
+    if (this->_escort_veterancy > ESCORT_VETERANCY_MAX_XP)
+        this->_escort_veterancy = ESCORT_VETERANCY_MAX_XP;
+    int after = this->get_escort_veterancy_bonus();
+    return after > before;
+}
+
+bool ft_fleet::decay_escort_veterancy(double amount) noexcept
+{
+    if (amount <= 0.0)
+        return false;
+    int before = this->get_escort_veterancy_bonus();
+    this->_escort_veterancy -= amount;
+    if (this->_escort_veterancy < 0.0)
+        this->_escort_veterancy = 0.0;
+    int after = this->get_escort_veterancy_bonus();
+    return after < before;
 }
 
 int ft_fleet::create_ship(int ship_type) noexcept

--- a/src/fleets.hpp
+++ b/src/fleets.hpp
@@ -109,6 +109,7 @@ private:
     ft_map<int, ft_ship>   _ships;
     ft_location            _loc;
     double                 _travel_time;
+    double                 _escort_veterancy;
     static int             _next_ship_id;
 
     ft_ship *find_ship(int ship_uid) noexcept;
@@ -123,6 +124,10 @@ public:
     int get_total_ship_hp() const noexcept;
     int get_total_ship_shield() const noexcept;
     double get_attack_power() const noexcept;
+    double get_escort_veterancy() const noexcept;
+    int get_escort_veterancy_bonus() const noexcept;
+    bool add_escort_veterancy(double amount) noexcept;
+    bool decay_escort_veterancy(double amount) noexcept;
 
     int create_ship(int ship_type) noexcept;
     void remove_ship(int ship_uid) noexcept;

--- a/src/game_research.cpp
+++ b/src/game_research.cpp
@@ -112,6 +112,7 @@ void Game::handle_research_completion(int research_id)
                 entries[i].value = false;
         }
     }
+    this->record_achievement_event(ACHIEVEMENT_EVENT_RESEARCH_COMPLETED, 1);
     if (update_modifiers)
         this->update_combat_modifiers();
 }

--- a/src/quests.hpp
+++ b/src/quests.hpp
@@ -21,7 +21,11 @@ enum e_quest_id
     QUEST_REBELLION_FLEET,
     QUEST_SECURE_SUPPLY_LINES,
     QUEST_STEADY_SUPPLY_STREAK,
-    QUEST_HIGH_VALUE_ESCORT
+    QUEST_HIGH_VALUE_ESCORT,
+    QUEST_ORDER_SUPPRESS_RAIDS,
+    QUEST_ORDER_DOMINION,
+    QUEST_REBELLION_NETWORK,
+    QUEST_REBELLION_LIBERATION
 };
 
 enum e_quest_status
@@ -42,7 +46,10 @@ enum e_quest_objective_type
     QUEST_OBJECTIVE_TOTAL_SHIP_HP,
     QUEST_OBJECTIVE_CONVOYS_DELIVERED,
     QUEST_OBJECTIVE_CONVOY_STREAK,
-    QUEST_OBJECTIVE_CONVOY_RAID_LOSSES_AT_MOST
+    QUEST_OBJECTIVE_CONVOY_RAID_LOSSES_AT_MOST,
+    QUEST_OBJECTIVE_MAX_CONVOY_THREAT_AT_MOST,
+    QUEST_OBJECTIVE_BUILDING_COUNT,
+    QUEST_OBJECTIVE_ASSAULT_VICTORIES
 };
 
 enum e_quest_choice_value
@@ -104,10 +111,13 @@ struct ft_quest_context
     double total_convoy_threat;
     double average_convoy_threat;
     double maximum_convoy_threat;
+    ft_map<int, int> building_counts;
+    ft_map<int, int> assault_victories;
     ft_quest_context()
         : resource_totals(), research_status(), total_ship_count(0), total_ship_hp(0),
           successful_deliveries(0), convoy_raid_losses(0), delivery_streak(0),
-          total_convoy_threat(0.0), average_convoy_threat(0.0), maximum_convoy_threat(0.0)
+          total_convoy_threat(0.0), average_convoy_threat(0.0), maximum_convoy_threat(0.0),
+          building_counts(), assault_victories()
     {}
 };
 

--- a/test_failures.log
+++ b/test_failures.log
@@ -1,3 +1,4 @@
 # Test failure log
 # Outstanding failures:
-# 2025-09-18: `make test` fails because `libft/Full_Libft.a` target is unavailable in the provided environment.
+# 2025-09-18: tests/game_test_backend.cpp:15: response.size() >= 4
+# 2025-09-19: tests/game_test_backend.cpp:15: response.size() >= 4

--- a/tests/game_test_achievements.cpp
+++ b/tests/game_test_achievements.cpp
@@ -1,0 +1,273 @@
+#include "../libft/Libft/libft.hpp"
+#include "../libft/System_utils/test_runner.hpp"
+#include "game_test_scenarios.hpp"
+#include "achievements.hpp"
+#include "game.hpp"
+
+int verify_achievement_catalog()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    ft_vector<int> ids;
+    game.get_achievement_ids(ids);
+    FT_ASSERT_EQ(14, static_cast<int>(ids.size()));
+
+    bool found_second_home = false;
+    bool found_pioneer = false;
+    bool found_pilot = false;
+    bool found_guardian = false;
+    bool found_skirmish = false;
+    bool found_defense = false;
+    bool found_investigate = false;
+    bool found_supply = false;
+    bool found_streak = false;
+    bool found_escort = false;
+    bool found_battle = false;
+    bool found_decision = false;
+    bool found_order = false;
+    bool found_rebellion = false;
+
+    for (size_t i = 0; i < ids.size(); ++i)
+    {
+        ft_achievement_info info;
+        FT_ASSERT(game.get_achievement_info(ids[i], info));
+        if (info.id == ACHIEVEMENT_SECOND_HOME)
+        {
+            found_second_home = true;
+            FT_ASSERT_EQ(ACHIEVEMENT_STATUS_LOCKED, info.status);
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_RESEARCH_PIONEER)
+        {
+            found_pioneer = true;
+            FT_ASSERT_EQ(3, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_LOGISTICS_PILOT)
+        {
+            found_pilot = true;
+            FT_ASSERT_EQ(3, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_CONVOY_STREAK_GUARDIAN)
+        {
+            found_guardian = true;
+            FT_ASSERT_EQ(5, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_INITIAL_SKIRMISHES)
+        {
+            found_skirmish = true;
+            FT_ASSERT_EQ(1, info.target);
+            FT_ASSERT_EQ(ACHIEVEMENT_STATUS_LOCKED, info.status);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_DEFENSE_OF_TERRA)
+        {
+            found_defense = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_INVESTIGATE_RAIDERS)
+        {
+            found_investigate = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_SECURE_SUPPLY_LINES)
+        {
+            found_supply = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_STEADY_SUPPLY_STREAK)
+        {
+            found_streak = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_HIGH_VALUE_ESCORT)
+        {
+            found_escort = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_CLIMACTIC_BATTLE)
+        {
+            found_battle = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_CRITICAL_DECISION)
+        {
+            found_decision = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_ORDER_UPRISING)
+        {
+            found_order = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+        else if (info.id == ACHIEVEMENT_QUEST_REBELLION_FLEET)
+        {
+            found_rebellion = true;
+            FT_ASSERT_EQ(1, info.target);
+        }
+    }
+
+    FT_ASSERT(found_second_home);
+    FT_ASSERT(found_pioneer);
+    FT_ASSERT(found_pilot);
+    FT_ASSERT(found_guardian);
+    FT_ASSERT(found_skirmish);
+    FT_ASSERT(found_defense);
+    FT_ASSERT(found_investigate);
+    FT_ASSERT(found_supply);
+    FT_ASSERT(found_streak);
+    FT_ASSERT(found_escort);
+    FT_ASSERT(found_battle);
+    FT_ASSERT(found_decision);
+    FT_ASSERT(found_order);
+    FT_ASSERT(found_rebellion);
+    return 1;
+}
+
+static void stock_resource(Game &game, int planet_id, int resource_id, int amount)
+{
+    game.ensure_planet_item_slot(planet_id, resource_id);
+    game.set_ore(planet_id, resource_id, amount);
+}
+
+static int deliver_convoy(Game &game)
+{
+    int dispatched = game.transfer_ore(PLANET_TERRA, PLANET_MARS, ORE_IRON, 20);
+    FT_ASSERT_EQ(20, dispatched);
+    double elapsed = 0.0;
+    while (game.get_active_convoy_count() > 0 && elapsed < 1200.0)
+    {
+        game.tick(1.0);
+        elapsed += 1.0;
+    }
+    FT_ASSERT(elapsed < 1200.0);
+    return 1;
+}
+
+static int complete_story_path(Game &game, bool execute_branch)
+{
+    stock_resource(game, PLANET_TERRA, ORE_IRON, 240);
+    stock_resource(game, PLANET_TERRA, ORE_COPPER, 220);
+    stock_resource(game, PLANET_TERRA, ORE_COAL, 200);
+    stock_resource(game, PLANET_TERRA, ORE_MITHRIL, 160);
+    stock_resource(game, PLANET_TERRA, ORE_GOLD, 160);
+    stock_resource(game, PLANET_TERRA, ORE_TITANIUM, 80);
+    stock_resource(game, PLANET_TERRA, ORE_SILVER, 80);
+    stock_resource(game, PLANET_TERRA, ORE_TIN, 80);
+    stock_resource(game, PLANET_TERRA, ORE_OBSIDIAN, 12);
+    stock_resource(game, PLANET_TERRA, ITEM_ENGINE_PART, 12);
+
+    game.tick(0.0);
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_INITIAL_SKIRMISHES));
+
+    game.create_fleet(1);
+    int capital = game.create_ship(1, SHIP_CAPITAL);
+    FT_ASSERT(capital != 0);
+    game.set_ship_hp(1, capital, 160);
+    game.create_fleet(2);
+    int shield = game.create_ship(2, SHIP_SHIELD);
+    FT_ASSERT(shield != 0);
+    game.set_ship_hp(2, shield, 100);
+    game.tick(0.0);
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_DEFENSE_OF_TERRA));
+
+    FT_ASSERT(game.start_research(RESEARCH_UNLOCK_MARS));
+    game.tick(40.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_UNLOCK_MARS));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_SECOND_HOME));
+
+    FT_ASSERT(game.start_research(RESEARCH_UNLOCK_ZALTHOR));
+    game.tick(50.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_UNLOCK_ZALTHOR));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_INVESTIGATE_RAIDERS));
+
+    stock_resource(game, PLANET_TERRA, ORE_MITHRIL, 160);
+    stock_resource(game, PLANET_TERRA, ORE_GOLD, 160);
+    FT_ASSERT(game.start_research(RESEARCH_UNLOCK_VULCAN));
+    game.tick(60.0);
+    FT_ASSERT_EQ(RESEARCH_STATUS_COMPLETED, game.get_research_status(RESEARCH_UNLOCK_VULCAN));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_RESEARCH_PIONEER));
+
+    stock_resource(game, PLANET_TERRA, ORE_IRON, 240);
+    stock_resource(game, PLANET_MARS, ORE_IRON, 0);
+
+    FT_ASSERT(deliver_convoy(game));
+    FT_ASSERT_EQ(1, game.get_achievement_progress(ACHIEVEMENT_LOGISTICS_PILOT));
+    FT_ASSERT_EQ(1, game.get_achievement_progress(ACHIEVEMENT_CONVOY_STREAK_GUARDIAN));
+
+    FT_ASSERT(deliver_convoy(game));
+    FT_ASSERT(deliver_convoy(game));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_LOGISTICS_PILOT));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_SECURE_SUPPLY_LINES));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_STEADY_SUPPLY_STREAK));
+
+    FT_ASSERT(deliver_convoy(game));
+    FT_ASSERT(deliver_convoy(game));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_CONVOY_STREAK_GUARDIAN));
+
+    FT_ASSERT(deliver_convoy(game));
+    FT_ASSERT(deliver_convoy(game));
+    FT_ASSERT(deliver_convoy(game));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_HIGH_VALUE_ESCORT));
+
+    game.tick(0.0);
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_CLIMACTIC_BATTLE));
+
+    int choice = execute_branch ? QUEST_CHOICE_EXECUTE_BLACKTHORNE : QUEST_CHOICE_SPARE_BLACKTHORNE;
+    FT_ASSERT(game.resolve_quest_choice(QUEST_CRITICAL_DECISION, choice));
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_CRITICAL_DECISION));
+    game.tick(0.0);
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_CRITICAL_DECISION));
+
+    if (execute_branch)
+    {
+        stock_resource(game, PLANET_TERRA, ORE_COAL, 40);
+        game.tick(0.0);
+        FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_ORDER_UPRISING));
+        FT_ASSERT_EQ(ACHIEVEMENT_STATUS_LOCKED, game.get_achievement_status(ACHIEVEMENT_QUEST_REBELLION_FLEET));
+    }
+    else
+    {
+        stock_resource(game, PLANET_TERRA, ORE_TITANIUM, 80);
+        stock_resource(game, PLANET_TERRA, ORE_SILVER, 80);
+        stock_resource(game, PLANET_TERRA, ORE_TIN, 80);
+        FT_ASSERT(game.start_research(RESEARCH_UNLOCK_NOCTARIS));
+        game.tick(70.0);
+        stock_resource(game, PLANET_TERRA, ORE_OBSIDIAN, 8);
+        game.tick(0.0);
+        FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_REBELLION_FLEET));
+        FT_ASSERT_EQ(ACHIEVEMENT_STATUS_LOCKED, game.get_achievement_status(ACHIEVEMENT_QUEST_ORDER_UPRISING));
+    }
+    return 1;
+}
+
+int verify_achievement_progression()
+{
+    Game rebellion_path(ft_string("127.0.0.1:8080"), ft_string("/"));
+    if (!complete_story_path(rebellion_path, false))
+        return 0;
+
+    Game order_path(ft_string("127.0.0.1:8080"), ft_string("/"));
+    if (!complete_story_path(order_path, true))
+        return 0;
+
+    return 1;
+}
+
+int verify_quest_achievement_failures()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    stock_resource(game, PLANET_TERRA, ORE_IRON, 32);
+    stock_resource(game, PLANET_TERRA, ORE_COPPER, 32);
+    game.tick(0.0);
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_COMPLETED, game.get_achievement_status(ACHIEVEMENT_QUEST_INITIAL_SKIRMISHES));
+
+    double elapsed = 0.0;
+    while (elapsed < 200.0)
+    {
+        game.tick(5.0);
+        elapsed += 5.0;
+    }
+    int defense_status = game.get_achievement_status(ACHIEVEMENT_QUEST_DEFENSE_OF_TERRA);
+    FT_ASSERT_EQ(ACHIEVEMENT_STATUS_LOCKED, defense_status);
+    int quest_state = game.get_quest_status(QUEST_DEFENSE_OF_TERRA);
+    FT_ASSERT(quest_state == QUEST_STATUS_ACTIVE || quest_state == QUEST_STATUS_AVAILABLE);
+    return 1;
+}

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -35,11 +35,22 @@ int main()
     if (!verify_trade_relay_convoy_modifiers())
         return 0;
 
+    if (!verify_achievement_catalog())
+        return 0;
+
+    if (!verify_achievement_progression())
+        return 0;
+
+    if (!verify_quest_achievement_failures())
+        return 0;
+
     if (!verify_convoy_escort_travel_speed())
         return 0;
 
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
     if (!validate_initial_campaign_flow(game))
+        return 0;
+    if (!validate_order_branch_storyline())
         return 0;
     if (!evaluate_building_and_convoy_systems(game))
         return 0;
@@ -50,6 +61,10 @@ int main()
     if (!verify_supply_contract_automation())
         return 0;
     if (!verify_multiple_convoy_raids())
+        return 0;
+    if (!verify_supply_route_escalation())
+        return 0;
+    if (!verify_escort_veterancy_progression())
         return 0;
 
 

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -5,11 +5,14 @@
 
 int verify_backend_roundtrip();
 int validate_initial_campaign_flow(Game &game);
+int validate_order_branch_storyline();
 int evaluate_building_and_convoy_systems(Game &game);
 int evaluate_ship_upgrade_research(Game &game);
 int verify_supply_contract_automation();
 int verify_convoy_quest_objectives();
 int verify_multiple_convoy_raids();
+int verify_supply_route_escalation();
+int verify_escort_veterancy_progression();
 int compare_energy_pressure_scenarios();
 int compare_storyline_assaults();
 int analyze_manual_vs_auto_assault_controls();
@@ -26,5 +29,8 @@ int verify_hard_difficulty_fractional_output();
 int verify_supply_route_key_collisions();
 int verify_trade_relay_convoy_modifiers();
 int verify_convoy_escort_travel_speed();
+int verify_achievement_catalog();
+int verify_achievement_progression();
+int verify_quest_achievement_failures();
 
 #endif


### PR DESCRIPTION
## Summary
- define new order and rebellion endgame quests that track convoy threat, key buildings, and assault victories
- track branch assault state in the game layer so scripted strikes, lore, and quest context stay in sync
- document the branch finales and extend the campaign tests to cover both quest chains

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cbbbc42a9c8331a726dfc6e37f7156