### PR TITLE
Add save system edge-case regression coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ SRC_COMMON  = \
     $(SRC_DIR)/game_convoys.cpp \
     $(SRC_DIR)/game_fleets.cpp \
     $(SRC_DIR)/game_combat_interface.cpp \
-    $(SRC_DIR)/game.cpp
+    $(SRC_DIR)/game.cpp \
+    $(SRC_DIR)/save_system.cpp
 SRC_MAIN    = $(SRC_DIR)/main.cpp
 SRC         = $(SRC_COMMON) $(SRC_MAIN)
 SRC_TEST    = $(SRC_COMMON) \
@@ -41,7 +42,8 @@ SRC_TEST    = $(SRC_COMMON) \
     $(TEST_DIR)/game_test_control.cpp \
     $(TEST_DIR)/game_test_support.cpp \
     $(TEST_DIR)/game_test_research.cpp \
-    $(TEST_DIR)/game_test_difficulty.cpp
+    $(TEST_DIR)/game_test_difficulty.cpp \
+    $(TEST_DIR)/game_test_save.cpp
 
 CC          = g++
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,32 @@ values with `set_ship_*`, `add_ship_*`, `sub_ship_*`, and query them with
 `set_fleet_location_travel`, or `set_fleet_location_misc`, and read its current
 location with `get_fleet_location`.
 
+## Save and Load Scaffolding
+
+Initial save/load support now lives in `SaveSystem`. The class wraps the `libft`
+JSON helpers so campaign state can be exported and restored without depending on
+the C++ standard library serializers. Two helpers are currently available:
+
+- `serialize_planets` / `deserialize_planets` round-trip the unlocked planet
+  map, including stored ore amounts, mining rates, and fractional carryover
+  buffers so production math stays stable after a reload.
+- `serialize_fleets` / `deserialize_fleets` persist fleet rosters, travel
+  assignments, escort veterancy, and all ship statistics. Fleet snapshots use
+  stable ship identifiers and scale floating-point values into integers to avoid
+  precision loss in JSON.
+
+The serializers rely on new accessors such as `ft_planet::get_carryover` and
+`ft_fleet::add_ship_snapshot` so game code can hand the `SaveSystem` concrete
+state. Once integrated with the campaign flow, these helpers enable quick
+checkpointing and prototyping of persistence features.
+
+`Game` now checkpoints automatically whenever a major quest completes or a
+research project finishes, stamping the snapshot with a descriptive tag such as
+`quest_completed_3` or `research_completed_12`. Campaign layers can also call
+`Game::save_campaign_checkpoint` directly to capture ad-hoc saves and
+`Game::reload_campaign_checkpoint` to restore the most recent snapshot using the
+embedded JSON state.
+
 ## Achievements
 
 The backend now tracks persistent achievements so campaign progress can trigger

--- a/src/fleets.cpp
+++ b/src/fleets.cpp
@@ -349,6 +349,15 @@ double ft_fleet::get_escort_veterancy() const noexcept
     return this->_escort_veterancy;
 }
 
+void ft_fleet::set_escort_veterancy(double value) noexcept
+{
+    if (value < 0.0)
+        value = 0.0;
+    if (value > ESCORT_VETERANCY_MAX_XP)
+        value = ESCORT_VETERANCY_MAX_XP;
+    this->_escort_veterancy = value;
+}
+
 int ft_fleet::get_escort_veterancy_bonus() const noexcept
 {
     if (this->_escort_veterancy <= 0.0)
@@ -395,6 +404,18 @@ int ft_fleet::create_ship(int ship_type) noexcept
     assign_ship_defaults(ship);
     this->_ships.insert(uid, ship);
     return uid;
+}
+
+void ft_fleet::clear_ships() noexcept
+{
+    this->_ships.clear();
+}
+
+void ft_fleet::add_ship_snapshot(const ft_ship &ship) noexcept
+{
+    this->_ships.insert(ship.id, ship);
+    if (ship.id >= _next_ship_id)
+        _next_ship_id = ship.id + 1;
 }
 
 void ft_fleet::remove_ship(int ship_uid) noexcept

--- a/src/fleets.hpp
+++ b/src/fleets.hpp
@@ -128,11 +128,14 @@ public:
     int get_escort_veterancy_bonus() const noexcept;
     bool add_escort_veterancy(double amount) noexcept;
     bool decay_escort_veterancy(double amount) noexcept;
+    void set_escort_veterancy(double value) noexcept;
 
     int create_ship(int ship_type) noexcept;
     void remove_ship(int ship_uid) noexcept;
     bool move_ship_to(ft_fleet &target, int ship_uid) noexcept;
     void move_ships_to(ft_fleet &target) noexcept;
+    void clear_ships() noexcept;
+    void add_ship_snapshot(const ft_ship &ship) noexcept;
 
     void set_ship_armor(int ship_uid, int value) noexcept;
     int get_ship_armor(int ship_uid) const noexcept;

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -9,6 +9,7 @@
 #include "combat.hpp"
 #include "buildings.hpp"
 #include "achievements.hpp"
+#include "save_system.hpp"
 #include "../libft/Game/game_state.hpp"
 #include "../libft/Template/map.hpp"
 #include "../libft/Template/vector.hpp"
@@ -65,6 +66,7 @@ private:
     ft_map<int, ft_sharedptr<ft_fleet> >          _fleets;
     ft_map<int, ft_sharedptr<ft_fleet> >          _planet_fleets;
     BackendClient                                _backend;
+    SaveSystem                                   _save_system;
     ResearchManager                              _research;
     QuestManager                                 _quests;
     CombatManager                                _combat;
@@ -149,6 +151,10 @@ private:
     int                                          _rebellion_branch_assault_victories;
     int                                          _order_branch_pending_assault;
     int                                          _rebellion_branch_pending_assault;
+    ft_string                                    _last_planet_checkpoint;
+    ft_string                                    _last_fleet_checkpoint;
+    ft_string                                    _last_checkpoint_tag;
+    bool                                         _has_checkpoint;
 
     ft_sharedptr<ft_planet> get_planet(int id);
     ft_sharedptr<const ft_planet> get_planet(int id) const;
@@ -211,6 +217,9 @@ private:
     void update_route_escalation(ft_supply_route &route, double seconds);
     void trigger_route_assault(ft_supply_route &route);
     void trigger_branch_assault(int planet_id, double difficulty, bool order_branch);
+    void apply_planet_snapshot(const ft_map<int, ft_sharedptr<ft_planet> > &snapshot);
+    void apply_fleet_snapshot(const ft_map<int, ft_sharedptr<ft_fleet> > &snapshot);
+    void checkpoint_campaign_state_internal(const ft_string &tag);
 
 public:
     Game(const ft_string &host, const ft_string &path, int difficulty = GAME_DIFFICULTY_STANDARD);
@@ -335,6 +344,14 @@ public:
     double get_fleet_travel_time(int fleet_id) const;
     int get_planet_fleet_ship_hp(int planet_id, int ship_uid) const;
     ft_location get_planet_fleet_location(int planet_id) const;
+
+    void save_campaign_checkpoint(const ft_string &tag) noexcept;
+    bool has_campaign_checkpoint() const noexcept;
+    const ft_string &get_campaign_planet_checkpoint() const noexcept;
+    const ft_string &get_campaign_fleet_checkpoint() const noexcept;
+    const ft_string &get_campaign_checkpoint_tag() const noexcept;
+    bool reload_campaign_checkpoint() noexcept;
+    bool load_campaign_from_save(const ft_string &planet_json, const ft_string &fleet_json) noexcept;
 };
 
 #endif

--- a/src/game_quests.cpp
+++ b/src/game_quests.cpp
@@ -180,6 +180,9 @@ void Game::handle_quest_completion(int quest_id)
     if (entry.size() > 0)
         this->_lore_log.push_back(entry);
     this->record_quest_achievement(quest_id);
+    ft_string tag("quest_completed_");
+    tag.append(ft_to_string(quest_id));
+    this->save_campaign_checkpoint(tag);
 }
 
 void Game::handle_quest_failure(int quest_id)

--- a/src/game_research.cpp
+++ b/src/game_research.cpp
@@ -115,6 +115,9 @@ void Game::handle_research_completion(int research_id)
     this->record_achievement_event(ACHIEVEMENT_EVENT_RESEARCH_COMPLETED, 1);
     if (update_modifiers)
         this->update_combat_modifiers();
+    ft_string tag("research_completed_");
+    tag.append(ft_to_string(research_id));
+    this->save_campaign_checkpoint(tag);
 }
 
 bool Game::can_start_research(int research_id) const

--- a/src/planets.cpp
+++ b/src/planets.cpp
@@ -146,6 +146,25 @@ const ft_vector<Pair<int, double> > &ft_planet::get_resources() const noexcept
     return this->_rates;
 }
 
+const ft_vector<Pair<int, double> > &ft_planet::get_carryover() const noexcept
+{
+    return this->_carryover;
+}
+
+void ft_planet::set_carryover(int ore_id, double amount) noexcept
+{
+    Pair<int, double> *entry = this->find_carryover(ore_id);
+    if (entry)
+    {
+        entry->value = amount;
+        return ;
+    }
+    Pair<int, double> carry;
+    carry.key = ore_id;
+    carry.value = amount;
+    this->_carryover.push_back(carry);
+}
+
 ft_vector<Pair<int, int> > ft_planet::produce(double seconds) noexcept
 {
     ft_vector<Pair<int, int> > produced;

--- a/src/planets.hpp
+++ b/src/planets.hpp
@@ -71,6 +71,8 @@ public:
     void set_resource(int ore_id, int amount) noexcept;
     double get_rate(int ore_id) const noexcept;
     const ft_vector<Pair<int, double> > &get_resources() const noexcept;
+    const ft_vector<Pair<int, double> > &get_carryover() const noexcept;
+    void set_carryover(int ore_id, double amount) noexcept;
     ft_vector<Pair<int, int> > produce(double seconds) noexcept;
 };
 

--- a/src/save_system.cpp
+++ b/src/save_system.cpp
@@ -1,0 +1,502 @@
+#include "save_system.hpp"
+#include "../libft/CMA/CMA.hpp"
+
+namespace
+{
+    const long SAVE_DOUBLE_SCALE = 1000000;
+}
+
+SaveSystem::SaveSystem() noexcept
+{
+    return ;
+}
+
+SaveSystem::~SaveSystem() noexcept
+{
+    return ;
+}
+
+long SaveSystem::scale_double_to_long(double value) const noexcept
+{
+    double scaled = value * static_cast<double>(SAVE_DOUBLE_SCALE);
+    if (scaled >= 0.0)
+        scaled += 0.5;
+    else
+        scaled -= 0.5;
+    long result = static_cast<long>(scaled);
+    return result;
+}
+
+double SaveSystem::unscale_long_to_double(long value) const noexcept
+{
+    if (SAVE_DOUBLE_SCALE == 0)
+        return 0.0;
+    double numerator = static_cast<double>(value);
+    double denominator = static_cast<double>(SAVE_DOUBLE_SCALE);
+    return numerator / denominator;
+}
+
+ft_sharedptr<ft_planet> SaveSystem::create_planet_instance(int planet_id) const noexcept
+{
+    switch (planet_id)
+    {
+    case PLANET_TERRA:
+        return ft_sharedptr<ft_planet>(new ft_planet_terra());
+    case PLANET_MARS:
+        return ft_sharedptr<ft_planet>(new ft_planet_mars());
+    case PLANET_ZALTHOR:
+        return ft_sharedptr<ft_planet>(new ft_planet_zalthor());
+    case PLANET_VULCAN:
+        return ft_sharedptr<ft_planet>(new ft_planet_vulcan());
+    case PLANET_NOCTARIS_PRIME:
+        return ft_sharedptr<ft_planet>(new ft_planet_noctaris_prime());
+    case PLANET_LUNA:
+        return ft_sharedptr<ft_planet>(new ft_planet_luna());
+    default:
+        return ft_sharedptr<ft_planet>(new ft_planet(planet_id));
+    }
+}
+
+ft_sharedptr<ft_fleet> SaveSystem::create_fleet_instance(int fleet_id) const noexcept
+{
+    ft_sharedptr<ft_fleet> fleet(new ft_fleet(fleet_id));
+    return fleet;
+}
+
+ft_string SaveSystem::serialize_planets(const ft_map<int, ft_sharedptr<ft_planet> > &planets) const noexcept
+{
+    json_document document;
+    size_t count = planets.size();
+    if (count > 0)
+    {
+        const Pair<int, ft_sharedptr<ft_planet> > *entries = planets.end();
+        entries -= count;
+        for (size_t i = 0; i < count; ++i)
+        {
+            ft_sharedptr<ft_planet> planet = entries[i].value;
+            if (!planet)
+                continue;
+            ft_string group_name = "planet_";
+            ft_string id_string = ft_to_string(entries[i].key);
+            group_name.append(id_string);
+            json_group *group = document.create_group(group_name.c_str());
+            if (!group)
+                continue;
+            document.append_group(group);
+            json_item *id_item = document.create_item("id", entries[i].key);
+            if (id_item)
+                document.add_item(group, id_item);
+            const ft_vector<Pair<int, double> > &resources = planet->get_resources();
+            for (size_t j = 0; j < resources.size(); ++j)
+            {
+                int ore_id = resources[j].key;
+                ft_string ore_string = ft_to_string(ore_id);
+                ft_string amount_key = "resource_";
+                amount_key.append(ore_string);
+                int amount = planet->get_resource(ore_id);
+                json_item *amount_item = document.create_item(amount_key.c_str(), amount);
+                if (amount_item)
+                    document.add_item(group, amount_item);
+                ft_string rate_key = "rate_";
+                rate_key.append(ore_string);
+                long scaled_rate = this->scale_double_to_long(resources[j].value);
+                ft_string rate_value = ft_to_string(scaled_rate);
+                json_item *rate_item = document.create_item(rate_key.c_str(), rate_value.c_str());
+                if (rate_item)
+                    document.add_item(group, rate_item);
+            }
+            const ft_vector<Pair<int, double> > &carryover = planet->get_carryover();
+            for (size_t j = 0; j < carryover.size(); ++j)
+            {
+                int ore_id = carryover[j].key;
+                ft_string ore_string = ft_to_string(ore_id);
+                ft_string carry_key = "carryover_";
+                carry_key.append(ore_string);
+                long scaled_carry = this->scale_double_to_long(carryover[j].value);
+                ft_string carry_value = ft_to_string(scaled_carry);
+                json_item *carry_item = document.create_item(carry_key.c_str(), carry_value.c_str());
+                if (carry_item)
+                    document.add_item(group, carry_item);
+            }
+        }
+    }
+    char *serialized = document.write_to_string();
+    if (!serialized)
+        return ft_string();
+    ft_string result(serialized);
+    cma_free(serialized);
+    return result;
+}
+
+bool SaveSystem::deserialize_planets(const char *content,
+    ft_map<int, ft_sharedptr<ft_planet> > &planets) const noexcept
+{
+    if (!content)
+        return false;
+    json_group *groups = json_read_from_string(content);
+    if (!groups)
+        return false;
+    planets.clear();
+    json_group *current = groups;
+    while (current)
+    {
+        json_item *id_item = json_find_item(current, "id");
+        if (!id_item)
+        {
+            current = current->next;
+            continue;
+        }
+        int planet_id = ft_atoi(id_item->value);
+        ft_sharedptr<ft_planet> planet = this->create_planet_instance(planet_id);
+        if (!planet)
+        {
+            current = current->next;
+            continue;
+        }
+        ft_vector<Pair<int, int> > resource_amounts;
+        ft_vector<Pair<int, long> > resource_rates;
+        ft_vector<Pair<int, long> > resource_carryover;
+        json_item *item = current->items;
+        while (item)
+        {
+            if (item->key && ft_strncmp(item->key, "resource_", 9) == 0)
+            {
+                int ore_id = ft_atoi(item->key + 9);
+                Pair<int, int> entry;
+                entry.key = ore_id;
+                entry.value = ft_atoi(item->value);
+                resource_amounts.push_back(entry);
+            }
+            else if (item->key && ft_strncmp(item->key, "rate_", 5) == 0)
+            {
+                int ore_id = ft_atoi(item->key + 5);
+                Pair<int, long> entry;
+                entry.key = ore_id;
+                entry.value = ft_atol(item->value);
+                resource_rates.push_back(entry);
+            }
+            else if (item->key && ft_strncmp(item->key, "carryover_", 10) == 0)
+            {
+                int ore_id = ft_atoi(item->key + 10);
+                Pair<int, long> entry;
+                entry.key = ore_id;
+                entry.value = ft_atol(item->value);
+                resource_carryover.push_back(entry);
+            }
+            item = item->next;
+        }
+        for (size_t i = 0; i < resource_rates.size(); ++i)
+        {
+            int ore_id = resource_rates[i].key;
+            double rate = this->unscale_long_to_double(resource_rates[i].value);
+            planet->register_resource(ore_id, rate);
+        }
+        for (size_t i = 0; i < resource_amounts.size(); ++i)
+        {
+            int ore_id = resource_amounts[i].key;
+            planet->register_resource(ore_id, planet->get_rate(ore_id));
+            planet->set_resource(ore_id, resource_amounts[i].value);
+        }
+        for (size_t i = 0; i < resource_carryover.size(); ++i)
+        {
+            int ore_id = resource_carryover[i].key;
+            double carry_value = this->unscale_long_to_double(resource_carryover[i].value);
+            planet->set_carryover(ore_id, carry_value);
+        }
+        planets.insert(planet_id, planet);
+        current = current->next;
+    }
+    json_free_groups(groups);
+    return true;
+}
+
+ft_string SaveSystem::serialize_fleets(const ft_map<int, ft_sharedptr<ft_fleet> > &fleets) const noexcept
+{
+    json_document document;
+    size_t count = fleets.size();
+    if (count > 0)
+    {
+        const Pair<int, ft_sharedptr<ft_fleet> > *entries = fleets.end();
+        entries -= count;
+        for (size_t i = 0; i < count; ++i)
+        {
+            ft_sharedptr<ft_fleet> fleet = entries[i].value;
+            if (!fleet)
+                continue;
+            ft_string group_name = "fleet_";
+            ft_string id_string = ft_to_string(entries[i].key);
+            group_name.append(id_string);
+            json_group *group = document.create_group(group_name.c_str());
+            if (!group)
+                continue;
+            document.append_group(group);
+            json_item *id_item = document.create_item("id", entries[i].key);
+            if (id_item)
+                document.add_item(group, id_item);
+            ft_location location = fleet->get_location();
+            json_item *type_item = document.create_item("location_type", location.type);
+            if (type_item)
+                document.add_item(group, type_item);
+            json_item *from_item = document.create_item("location_from", location.from);
+            if (from_item)
+                document.add_item(group, from_item);
+            json_item *to_item = document.create_item("location_to", location.to);
+            if (to_item)
+                document.add_item(group, to_item);
+            json_item *misc_item = document.create_item("location_misc", location.misc);
+            if (misc_item)
+                document.add_item(group, misc_item);
+            long travel_scaled = this->scale_double_to_long(fleet->get_travel_time());
+            ft_string travel_value = ft_to_string(travel_scaled);
+            json_item *travel_item = document.create_item("travel_time", travel_value.c_str());
+            if (travel_item)
+                document.add_item(group, travel_item);
+            long veterancy_scaled = this->scale_double_to_long(fleet->get_escort_veterancy());
+            ft_string veterancy_value = ft_to_string(veterancy_scaled);
+            json_item *veterancy_item = document.create_item("escort_veterancy", veterancy_value.c_str());
+            if (veterancy_item)
+                document.add_item(group, veterancy_item);
+            int ship_total = fleet->get_ship_count();
+            json_item *ship_count_item = document.create_item("ship_count", ship_total);
+            if (ship_count_item)
+                document.add_item(group, ship_count_item);
+            ft_vector<int> ship_ids;
+            fleet->get_ship_ids(ship_ids);
+            for (size_t j = 0; j < ship_ids.size(); ++j)
+            {
+                int ship_id = ship_ids[j];
+                const ft_ship *ship = fleet->get_ship(ship_id);
+                if (!ship)
+                    continue;
+                ft_string index_string = ft_to_string(static_cast<long>(j));
+                ft_string base_key = "ship_";
+                base_key.append(index_string);
+                ft_string key = base_key;
+                key.append("_id");
+                json_item *ship_id_item = document.create_item(key.c_str(), ship->id);
+                if (ship_id_item)
+                    document.add_item(group, ship_id_item);
+                key = base_key;
+                key.append("_type");
+                json_item *ship_type_item = document.create_item(key.c_str(), ship->type);
+                if (ship_type_item)
+                    document.add_item(group, ship_type_item);
+                key = base_key;
+                key.append("_armor");
+                json_item *armor_item = document.create_item(key.c_str(), ship->armor);
+                if (armor_item)
+                    document.add_item(group, armor_item);
+                key = base_key;
+                key.append("_hp");
+                json_item *hp_item = document.create_item(key.c_str(), ship->hp);
+                if (hp_item)
+                    document.add_item(group, hp_item);
+                key = base_key;
+                key.append("_shield");
+                json_item *shield_item = document.create_item(key.c_str(), ship->shield);
+                if (shield_item)
+                    document.add_item(group, shield_item);
+                key = base_key;
+                key.append("_max_hp");
+                json_item *max_hp_item = document.create_item(key.c_str(), ship->max_hp);
+                if (max_hp_item)
+                    document.add_item(group, max_hp_item);
+                key = base_key;
+                key.append("_max_shield");
+                json_item *max_shield_item = document.create_item(key.c_str(), ship->max_shield);
+                if (max_shield_item)
+                    document.add_item(group, max_shield_item);
+                key = base_key;
+                key.append("_max_speed");
+                long max_speed_scaled = this->scale_double_to_long(ship->max_speed);
+                ft_string max_speed_value = ft_to_string(max_speed_scaled);
+                json_item *max_speed_item = document.create_item(key.c_str(), max_speed_value.c_str());
+                if (max_speed_item)
+                    document.add_item(group, max_speed_item);
+                key = base_key;
+                key.append("_acceleration");
+                long acceleration_scaled = this->scale_double_to_long(ship->acceleration);
+                ft_string acceleration_value = ft_to_string(acceleration_scaled);
+                json_item *acceleration_item = document.create_item(key.c_str(), acceleration_value.c_str());
+                if (acceleration_item)
+                    document.add_item(group, acceleration_item);
+                key = base_key;
+                key.append("_turn_speed");
+                long turn_speed_scaled = this->scale_double_to_long(ship->turn_speed);
+                ft_string turn_speed_value = ft_to_string(turn_speed_scaled);
+                json_item *turn_speed_item = document.create_item(key.c_str(), turn_speed_value.c_str());
+                if (turn_speed_item)
+                    document.add_item(group, turn_speed_item);
+                key = base_key;
+                key.append("_behavior");
+                json_item *behavior_item = document.create_item(key.c_str(), ship->combat_behavior);
+                if (behavior_item)
+                    document.add_item(group, behavior_item);
+                key = base_key;
+                key.append("_outnumbered");
+                json_item *outnumbered_item = document.create_item(key.c_str(), ship->outnumbered_behavior);
+                if (outnumbered_item)
+                    document.add_item(group, outnumbered_item);
+                key = base_key;
+                key.append("_unescorted");
+                json_item *unescorted_item = document.create_item(key.c_str(), ship->unescorted_behavior);
+                if (unescorted_item)
+                    document.add_item(group, unescorted_item);
+                key = base_key;
+                key.append("_low_hp");
+                json_item *low_hp_item = document.create_item(key.c_str(), ship->low_hp_behavior);
+                if (low_hp_item)
+                    document.add_item(group, low_hp_item);
+                key = base_key;
+                key.append("_role");
+                json_item *role_item = document.create_item(key.c_str(), ship->role);
+                if (role_item)
+                    document.add_item(group, role_item);
+            }
+        }
+    }
+    char *serialized = document.write_to_string();
+    if (!serialized)
+        return ft_string();
+    ft_string result(serialized);
+    cma_free(serialized);
+    return result;
+}
+
+bool SaveSystem::deserialize_fleets(const char *content,
+    ft_map<int, ft_sharedptr<ft_fleet> > &fleets) const noexcept
+{
+    if (!content)
+        return false;
+    json_group *groups = json_read_from_string(content);
+    if (!groups)
+        return false;
+    fleets.clear();
+    json_group *current = groups;
+    while (current)
+    {
+        json_item *id_item = json_find_item(current, "id");
+        if (!id_item)
+        {
+            current = current->next;
+            continue;
+        }
+        int fleet_id = ft_atoi(id_item->value);
+        ft_sharedptr<ft_fleet> fleet = this->create_fleet_instance(fleet_id);
+        if (!fleet)
+        {
+            current = current->next;
+            continue;
+        }
+        json_item *type_item = json_find_item(current, "location_type");
+        int location_type = type_item ? ft_atoi(type_item->value) : LOCATION_PLANET;
+        json_item *from_item = json_find_item(current, "location_from");
+        int location_from = from_item ? ft_atoi(from_item->value) : PLANET_TERRA;
+        json_item *to_item = json_find_item(current, "location_to");
+        int location_to = to_item ? ft_atoi(to_item->value) : PLANET_TERRA;
+        json_item *misc_item = json_find_item(current, "location_misc");
+        int location_misc = misc_item ? ft_atoi(misc_item->value) : 0;
+        json_item *travel_item = json_find_item(current, "travel_time");
+        long travel_scaled = travel_item ? ft_atol(travel_item->value) : 0;
+        json_item *veterancy_item = json_find_item(current, "escort_veterancy");
+        long veterancy_scaled = veterancy_item ? ft_atol(veterancy_item->value) : 0;
+        if (location_type == LOCATION_TRAVEL)
+            fleet->set_location_travel(location_from, location_to,
+                this->unscale_long_to_double(travel_scaled));
+        else if (location_type == LOCATION_MISC)
+            fleet->set_location_misc(location_misc);
+        else
+            fleet->set_location_planet(location_from);
+        fleet->set_escort_veterancy(this->unscale_long_to_double(veterancy_scaled));
+        json_item *ship_count_item = json_find_item(current, "ship_count");
+        int ship_count = ship_count_item ? ft_atoi(ship_count_item->value) : 0;
+        for (int i = 0; i < ship_count; ++i)
+        {
+            ft_string index_string = ft_to_string(static_cast<long>(i));
+            ft_string base_key = "ship_";
+            base_key.append(index_string);
+            ft_string key = base_key;
+            key.append("_id");
+            json_item *ship_id_item = json_find_item(current, key.c_str());
+            if (!ship_id_item)
+                continue;
+            ft_ship ship_snapshot;
+            ship_snapshot.id = ft_atoi(ship_id_item->value);
+            key = base_key;
+            key.append("_type");
+            json_item *ship_type_item = json_find_item(current, key.c_str());
+            if (ship_type_item)
+                ship_snapshot.type = ft_atoi(ship_type_item->value);
+            key = base_key;
+            key.append("_armor");
+            json_item *armor_item = json_find_item(current, key.c_str());
+            if (armor_item)
+                ship_snapshot.armor = ft_atoi(armor_item->value);
+            key = base_key;
+            key.append("_hp");
+            json_item *hp_item = json_find_item(current, key.c_str());
+            if (hp_item)
+                ship_snapshot.hp = ft_atoi(hp_item->value);
+            key = base_key;
+            key.append("_shield");
+            json_item *shield_item = json_find_item(current, key.c_str());
+            if (shield_item)
+                ship_snapshot.shield = ft_atoi(shield_item->value);
+            key = base_key;
+            key.append("_max_hp");
+            json_item *max_hp_item = json_find_item(current, key.c_str());
+            if (max_hp_item)
+                ship_snapshot.max_hp = ft_atoi(max_hp_item->value);
+            key = base_key;
+            key.append("_max_shield");
+            json_item *max_shield_item = json_find_item(current, key.c_str());
+            if (max_shield_item)
+                ship_snapshot.max_shield = ft_atoi(max_shield_item->value);
+            key = base_key;
+            key.append("_max_speed");
+            json_item *max_speed_item = json_find_item(current, key.c_str());
+            if (max_speed_item)
+                ship_snapshot.max_speed = this->unscale_long_to_double(ft_atol(max_speed_item->value));
+            key = base_key;
+            key.append("_acceleration");
+            json_item *acceleration_item = json_find_item(current, key.c_str());
+            if (acceleration_item)
+                ship_snapshot.acceleration = this->unscale_long_to_double(ft_atol(acceleration_item->value));
+            key = base_key;
+            key.append("_turn_speed");
+            json_item *turn_speed_item = json_find_item(current, key.c_str());
+            if (turn_speed_item)
+                ship_snapshot.turn_speed = this->unscale_long_to_double(ft_atol(turn_speed_item->value));
+            key = base_key;
+            key.append("_behavior");
+            json_item *behavior_item = json_find_item(current, key.c_str());
+            if (behavior_item)
+                ship_snapshot.combat_behavior = ft_atoi(behavior_item->value);
+            key = base_key;
+            key.append("_outnumbered");
+            json_item *outnumbered_item = json_find_item(current, key.c_str());
+            if (outnumbered_item)
+                ship_snapshot.outnumbered_behavior = ft_atoi(outnumbered_item->value);
+            key = base_key;
+            key.append("_unescorted");
+            json_item *unescorted_item = json_find_item(current, key.c_str());
+            if (unescorted_item)
+                ship_snapshot.unescorted_behavior = ft_atoi(unescorted_item->value);
+            key = base_key;
+            key.append("_low_hp");
+            json_item *low_hp_item = json_find_item(current, key.c_str());
+            if (low_hp_item)
+                ship_snapshot.low_hp_behavior = ft_atoi(low_hp_item->value);
+            key = base_key;
+            key.append("_role");
+            json_item *role_item = json_find_item(current, key.c_str());
+            if (role_item)
+                ship_snapshot.role = ft_atoi(role_item->value);
+            fleet->add_ship_snapshot(ship_snapshot);
+        }
+        fleets.insert(fleet_id, fleet);
+        current = current->next;
+    }
+    json_free_groups(groups);
+    return true;
+}

--- a/src/save_system.hpp
+++ b/src/save_system.hpp
@@ -1,0 +1,33 @@
+#ifndef SAVE_SYSTEM_HPP
+#define SAVE_SYSTEM_HPP
+
+#include "planets.hpp"
+#include "fleets.hpp"
+#include "../libft/JSon/document.hpp"
+#include "../libft/JSon/json.hpp"
+#include "../libft/CPP_class/class_string_class.hpp"
+#include "../libft/Libft/libft.hpp"
+#include "../libft/Template/pair.hpp"
+
+class SaveSystem
+{
+public:
+    SaveSystem() noexcept;
+    ~SaveSystem() noexcept;
+
+    ft_string serialize_planets(const ft_map<int, ft_sharedptr<ft_planet> > &planets) const noexcept;
+    bool deserialize_planets(const char *content,
+        ft_map<int, ft_sharedptr<ft_planet> > &planets) const noexcept;
+
+    ft_string serialize_fleets(const ft_map<int, ft_sharedptr<ft_fleet> > &fleets) const noexcept;
+    bool deserialize_fleets(const char *content,
+        ft_map<int, ft_sharedptr<ft_fleet> > &fleets) const noexcept;
+
+private:
+    ft_sharedptr<ft_planet> create_planet_instance(int planet_id) const noexcept;
+    ft_sharedptr<ft_fleet> create_fleet_instance(int fleet_id) const noexcept;
+    long scale_double_to_long(double value) const noexcept;
+    double unscale_long_to_double(long value) const noexcept;
+};
+
+#endif

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -90,6 +90,14 @@ int main()
         return 0;
     if (!verify_auxiliary_and_escape_protocol())
         return 0;
+    if (!verify_save_system_round_trip())
+        return 0;
+    if (!verify_save_system_edge_cases())
+        return 0;
+    if (!validate_save_system_serialized_samples())
+        return 0;
+    if (!verify_campaign_checkpoint_flow())
+        return 0;
 
     server_thread.join();
     return 0;

--- a/tests/game_test_save.cpp
+++ b/tests/game_test_save.cpp
@@ -1,0 +1,385 @@
+#include "../libft/Libft/libft.hpp"
+#include "../libft/System_utils/test_runner.hpp"
+#include "../libft/Template/vector.hpp"
+#include "../libft/Template/map.hpp"
+#include "../libft/Template/pair.hpp"
+#include "../libft/JSon/document.hpp"
+#include "../libft/JSon/json.hpp"
+#include "../libft/CMA/CMA.hpp"
+#include "save_system.hpp"
+#include "game_test_scenarios.hpp"
+
+static double ft_absolute(double value)
+{
+    if (value < 0.0)
+        return -value;
+    return value;
+}
+
+static long reference_scale_double(double value)
+{
+    double scaled = value * 1000000.0;
+    if (scaled >= 0.0)
+        scaled += 0.5;
+    else
+        scaled -= 0.5;
+    return static_cast<long>(scaled);
+}
+
+int verify_save_system_round_trip()
+{
+    SaveSystem saves;
+    ft_map<int, ft_sharedptr<ft_planet> > planets;
+    ft_sharedptr<ft_planet> terra(new ft_planet_terra());
+    terra->register_resource(ORE_IRON, 1234567.890123);
+    terra->set_resource(ORE_IRON, 4200);
+    terra->set_carryover(ORE_IRON, 0.765432);
+    terra->register_resource(ORE_COPPER, 345.678901);
+    terra->set_resource(ORE_COPPER, 9001);
+    terra->set_carryover(ORE_COPPER, 0.123456);
+    planets.insert(PLANET_TERRA, terra);
+
+    ft_map<int, ft_sharedptr<ft_fleet> > fleets;
+    ft_sharedptr<ft_fleet> fleet(new ft_fleet(88));
+    fleet->set_location_travel(PLANET_TERRA, PLANET_MARS, 512.204);
+    fleet->set_escort_veterancy(3.141592);
+    ft_ship cruiser;
+    cruiser.id = 501;
+    cruiser.type = SHIP_CAPITAL;
+    cruiser.hp = 275;
+    cruiser.max_hp = 420;
+    cruiser.shield = 180;
+    cruiser.max_shield = 220;
+    cruiser.max_speed = 987.654321;
+    cruiser.acceleration = 12.345678;
+    cruiser.turn_speed = 210.987654;
+    cruiser.combat_behavior = SHIP_BEHAVIOR_CHARGE;
+    cruiser.role = SHIP_ROLE_LINE;
+    fleet->add_ship_snapshot(cruiser);
+    ft_ship escort;
+    escort.id = 777;
+    escort.type = SHIP_SHIELD;
+    escort.hp = 120;
+    escort.max_hp = 160;
+    escort.shield = 240;
+    escort.max_shield = 260;
+    escort.max_speed = 654.321098;
+    escort.acceleration = 9.876543;
+    escort.turn_speed = 198.765432;
+    escort.combat_behavior = SHIP_BEHAVIOR_SCREEN_SUPPORT;
+    escort.role = SHIP_ROLE_SUPPORT;
+    fleet->add_ship_snapshot(escort);
+    fleets.insert(88, fleet);
+
+    ft_string planet_json = saves.serialize_planets(planets);
+    ft_string fleet_json = saves.serialize_fleets(fleets);
+    FT_ASSERT(planet_json.size() > 0);
+    FT_ASSERT(fleet_json.size() > 0);
+
+    ft_map<int, ft_sharedptr<ft_planet> > restored_planets;
+    ft_map<int, ft_sharedptr<ft_fleet> > restored_fleets;
+    FT_ASSERT(saves.deserialize_planets(planet_json.c_str(), restored_planets));
+    FT_ASSERT(saves.deserialize_fleets(fleet_json.c_str(), restored_fleets));
+
+    Pair<int, ft_sharedptr<ft_planet> > *terra_entry = restored_planets.find(PLANET_TERRA);
+    FT_ASSERT(terra_entry != ft_nullptr);
+    ft_sharedptr<ft_planet> restored_terra = terra_entry->value;
+    FT_ASSERT(restored_terra);
+    double iron_rate = restored_terra->get_rate(ORE_IRON);
+    FT_ASSERT(ft_absolute(iron_rate - 1234567.890123) < 0.000001);
+    FT_ASSERT_EQ(4200, restored_terra->get_resource(ORE_IRON));
+    const ft_vector<Pair<int, double> > &terra_carry = restored_terra->get_carryover();
+    double iron_carry = 0.0;
+    for (size_t i = 0; i < terra_carry.size(); ++i)
+    {
+        if (terra_carry[i].key == ORE_IRON)
+            iron_carry = terra_carry[i].value;
+    }
+    FT_ASSERT(ft_absolute(iron_carry - 0.765432) < 0.000001);
+
+    Pair<int, ft_sharedptr<ft_fleet> > *fleet_entry = restored_fleets.find(88);
+    FT_ASSERT(fleet_entry != ft_nullptr);
+    ft_sharedptr<ft_fleet> restored_fleet = fleet_entry->value;
+    FT_ASSERT(restored_fleet);
+    ft_location restored_loc = restored_fleet->get_location();
+    FT_ASSERT_EQ(LOCATION_TRAVEL, restored_loc.type);
+    FT_ASSERT_EQ(PLANET_TERRA, restored_loc.from);
+    FT_ASSERT_EQ(PLANET_MARS, restored_loc.to);
+    FT_ASSERT(ft_absolute(restored_fleet->get_travel_time() - 512.204) < 0.000001);
+    FT_ASSERT(ft_absolute(restored_fleet->get_escort_veterancy() - 3.141592) < 0.000001);
+    const ft_ship *restored_cruiser = restored_fleet->get_ship(501);
+    FT_ASSERT(restored_cruiser != ft_nullptr);
+    FT_ASSERT(ft_absolute(restored_cruiser->max_speed - 987.654321) < 0.000001);
+    FT_ASSERT_EQ(420, restored_cruiser->max_hp);
+    const ft_ship *restored_escort = restored_fleet->get_ship(777);
+    FT_ASSERT(restored_escort != ft_nullptr);
+    FT_ASSERT(ft_absolute(restored_escort->acceleration - 9.876543) < 0.000001);
+    FT_ASSERT_EQ(SHIP_ROLE_SUPPORT, restored_escort->role);
+
+    return 1;
+}
+
+int verify_save_system_edge_cases()
+{
+    SaveSystem saves;
+
+    ft_map<int, ft_sharedptr<ft_planet> > empty_planets;
+    ft_string empty_planet_json = saves.serialize_planets(empty_planets);
+    if (empty_planet_json.size() > 0)
+    {
+        ft_map<int, ft_sharedptr<ft_planet> > roundtrip_empty_planets;
+        FT_ASSERT(saves.deserialize_planets(empty_planet_json.c_str(), roundtrip_empty_planets));
+        FT_ASSERT_EQ(0u, roundtrip_empty_planets.size());
+    }
+
+    ft_map<int, ft_sharedptr<ft_fleet> > empty_fleets;
+    ft_string empty_fleet_json = saves.serialize_fleets(empty_fleets);
+    if (empty_fleet_json.size() > 0)
+    {
+        ft_map<int, ft_sharedptr<ft_fleet> > roundtrip_empty_fleets;
+        FT_ASSERT(saves.deserialize_fleets(empty_fleet_json.c_str(), roundtrip_empty_fleets));
+        FT_ASSERT_EQ(0u, roundtrip_empty_fleets.size());
+    }
+
+    json_document planet_doc;
+    json_group *planet_group = planet_doc.create_group("planet_sparse");
+    FT_ASSERT(planet_group != ft_nullptr);
+    planet_doc.append_group(planet_group);
+    json_item *planet_id_item = planet_doc.create_item("id", PLANET_MARS);
+    FT_ASSERT(planet_id_item != ft_nullptr);
+    planet_doc.add_item(planet_group, planet_id_item);
+    json_item *amount_item = planet_doc.create_item("resource_1", 12);
+    FT_ASSERT(amount_item != ft_nullptr);
+    planet_doc.add_item(planet_group, amount_item);
+    char *sparse_planet_raw = planet_doc.write_to_string();
+    FT_ASSERT(sparse_planet_raw != ft_nullptr);
+    ft_string sparse_planet_json(sparse_planet_raw);
+    cma_free(sparse_planet_raw);
+    ft_map<int, ft_sharedptr<ft_planet> > sparse_planets;
+    FT_ASSERT(saves.deserialize_planets(sparse_planet_json.c_str(), sparse_planets));
+    Pair<int, ft_sharedptr<ft_planet> > *sparse_entry = sparse_planets.find(PLANET_MARS);
+    FT_ASSERT(sparse_entry != ft_nullptr);
+    FT_ASSERT_EQ(12, sparse_entry->value->get_resource(ORE_IRON));
+    FT_ASSERT(ft_absolute(sparse_entry->value->get_rate(ORE_IRON)) < 0.000001);
+
+    json_document fleet_doc;
+    json_group *fleet_group = fleet_doc.create_group("fleet_sparse");
+    FT_ASSERT(fleet_group != ft_nullptr);
+    fleet_doc.append_group(fleet_group);
+    json_item *fleet_id_item = fleet_doc.create_item("id", 55);
+    FT_ASSERT(fleet_id_item != ft_nullptr);
+    fleet_doc.add_item(fleet_group, fleet_id_item);
+    json_item *fleet_ship_count = fleet_doc.create_item("ship_count", 1);
+    FT_ASSERT(fleet_ship_count != ft_nullptr);
+    fleet_doc.add_item(fleet_group, fleet_ship_count);
+    json_item *fleet_ship_id = fleet_doc.create_item("ship_0_id", 333);
+    FT_ASSERT(fleet_ship_id != ft_nullptr);
+    fleet_doc.add_item(fleet_group, fleet_ship_id);
+    char *sparse_fleet_raw = fleet_doc.write_to_string();
+    FT_ASSERT(sparse_fleet_raw != ft_nullptr);
+    ft_string sparse_fleet_json(sparse_fleet_raw);
+    cma_free(sparse_fleet_raw);
+    ft_map<int, ft_sharedptr<ft_fleet> > sparse_fleets;
+    FT_ASSERT(saves.deserialize_fleets(sparse_fleet_json.c_str(), sparse_fleets));
+    Pair<int, ft_sharedptr<ft_fleet> > *sparse_fleet_entry = sparse_fleets.find(55);
+    FT_ASSERT(sparse_fleet_entry != ft_nullptr);
+    FT_ASSERT_EQ(1, sparse_fleet_entry->value->get_ship_count());
+    const ft_ship *sparse_ship = sparse_fleet_entry->value->get_ship(333);
+    FT_ASSERT(sparse_ship != ft_nullptr);
+    FT_ASSERT_EQ(0, sparse_ship->hp);
+    FT_ASSERT_EQ(0, sparse_ship->shield);
+    ft_location sparse_location = sparse_fleet_entry->value->get_location();
+    FT_ASSERT_EQ(LOCATION_PLANET, sparse_location.type);
+    FT_ASSERT_EQ(PLANET_TERRA, sparse_location.from);
+    FT_ASSERT_EQ(PLANET_TERRA, sparse_location.to);
+    FT_ASSERT(ft_absolute(sparse_fleet_entry->value->get_escort_veterancy()) < 0.000001);
+
+    return 1;
+}
+
+int validate_save_system_serialized_samples()
+{
+    SaveSystem saves;
+
+    ft_map<int, ft_sharedptr<ft_planet> > planets;
+    ft_sharedptr<ft_planet> vulcan(new ft_planet_vulcan());
+    double large_rate = 123456789012.345678;
+    double large_carryover = 6543210.987654;
+    int large_stock = 2147480000;
+    vulcan->register_resource(ORE_GOLD, large_rate);
+    vulcan->set_resource(ORE_GOLD, large_stock);
+    vulcan->set_carryover(ORE_GOLD, large_carryover);
+    planets.insert(PLANET_VULCAN, vulcan);
+
+    ft_map<int, ft_sharedptr<ft_fleet> > fleets;
+    ft_sharedptr<ft_fleet> armada(new ft_fleet(404));
+    double travel_time = 654321.987654;
+    double veterancy = 87654.321987;
+    armada->set_location_travel(PLANET_VULCAN, PLANET_MARS, travel_time);
+    armada->set_escort_veterancy(veterancy);
+    ft_ship dreadnought;
+    dreadnought.id = 9001;
+    dreadnought.type = SHIP_CAPITAL_DREADNOUGHT;
+    dreadnought.armor = 987654321;
+    dreadnought.hp = 1900000000;
+    dreadnought.shield = 1850000000;
+    dreadnought.max_hp = 2000000000;
+    dreadnought.max_shield = 2100000000;
+    dreadnought.max_speed = 43210.987654;
+    dreadnought.acceleration = 321.987654;
+    dreadnought.turn_speed = 210.123456;
+    dreadnought.combat_behavior = SHIP_BEHAVIOR_LAST_STAND;
+    dreadnought.outnumbered_behavior = SHIP_BEHAVIOR_CHARGE;
+    dreadnought.unescorted_behavior = SHIP_BEHAVIOR_WITHDRAW_SUPPORT;
+    dreadnought.low_hp_behavior = SHIP_BEHAVIOR_FLANK_SWEEP;
+    dreadnought.role = SHIP_ROLE_SUPPORT;
+    armada->add_ship_snapshot(dreadnought);
+    fleets.insert(404, armada);
+
+    ft_string planet_json = saves.serialize_planets(planets);
+    FT_ASSERT(planet_json.size() > 0);
+    ft_string fleet_json = saves.serialize_fleets(fleets);
+    FT_ASSERT(fleet_json.size() > 0);
+
+    json_group *planet_groups = json_read_from_string(planet_json.c_str());
+    FT_ASSERT(planet_groups != ft_nullptr);
+    json_group *planet_group = planet_groups;
+    while (planet_group)
+    {
+        json_item *id_item = json_find_item(planet_group, "id");
+        if (id_item && ft_atoi(id_item->value) == PLANET_VULCAN)
+            break;
+        planet_group = planet_group->next;
+    }
+    FT_ASSERT(planet_group != ft_nullptr);
+    ft_string rate_key = "rate_";
+    rate_key.append(ft_to_string(ORE_GOLD));
+    json_item *rate_item = json_find_item(planet_group, rate_key.c_str());
+    FT_ASSERT(rate_item != ft_nullptr);
+    FT_ASSERT_EQ(reference_scale_double(large_rate), ft_atol(rate_item->value));
+    ft_string carry_key = "carryover_";
+    carry_key.append(ft_to_string(ORE_GOLD));
+    json_item *carry_item = json_find_item(planet_group, carry_key.c_str());
+    FT_ASSERT(carry_item != ft_nullptr);
+    FT_ASSERT_EQ(reference_scale_double(large_carryover), ft_atol(carry_item->value));
+    ft_string amount_key = "resource_";
+    amount_key.append(ft_to_string(ORE_GOLD));
+    json_item *amount_item = json_find_item(planet_group, amount_key.c_str());
+    FT_ASSERT(amount_item != ft_nullptr);
+    FT_ASSERT_EQ(large_stock, ft_atoi(amount_item->value));
+    json_free_groups(planet_groups);
+
+    json_group *fleet_groups = json_read_from_string(fleet_json.c_str());
+    FT_ASSERT(fleet_groups != ft_nullptr);
+    json_group *fleet_group = fleet_groups;
+    while (fleet_group)
+    {
+        json_item *fleet_id = json_find_item(fleet_group, "id");
+        if (fleet_id && ft_atoi(fleet_id->value) == 404)
+            break;
+        fleet_group = fleet_group->next;
+    }
+    FT_ASSERT(fleet_group != ft_nullptr);
+    json_item *travel_item = json_find_item(fleet_group, "travel_time");
+    FT_ASSERT(travel_item != ft_nullptr);
+    FT_ASSERT_EQ(reference_scale_double(travel_time), ft_atol(travel_item->value));
+    json_item *veterancy_item = json_find_item(fleet_group, "escort_veterancy");
+    FT_ASSERT(veterancy_item != ft_nullptr);
+    FT_ASSERT_EQ(reference_scale_double(veterancy), ft_atol(veterancy_item->value));
+    json_item *ship_count_item = json_find_item(fleet_group, "ship_count");
+    FT_ASSERT(ship_count_item != ft_nullptr);
+    FT_ASSERT_EQ(1, ft_atoi(ship_count_item->value));
+    ft_string ship_base = "ship_";
+    ship_base.append(ft_to_string(0));
+    ft_string ship_speed_key = ship_base;
+    ship_speed_key.append("_max_speed");
+    json_item *ship_speed_item = json_find_item(fleet_group, ship_speed_key.c_str());
+    FT_ASSERT(ship_speed_item != ft_nullptr);
+    FT_ASSERT_EQ(reference_scale_double(dreadnought.max_speed), ft_atol(ship_speed_item->value));
+    ft_string ship_accel_key = ship_base;
+    ship_accel_key.append("_acceleration");
+    json_item *ship_accel_item = json_find_item(fleet_group, ship_accel_key.c_str());
+    FT_ASSERT(ship_accel_item != ft_nullptr);
+    FT_ASSERT_EQ(reference_scale_double(dreadnought.acceleration), ft_atol(ship_accel_item->value));
+    ft_string ship_turn_key = ship_base;
+    ship_turn_key.append("_turn_speed");
+    json_item *ship_turn_item = json_find_item(fleet_group, ship_turn_key.c_str());
+    FT_ASSERT(ship_turn_item != ft_nullptr);
+    FT_ASSERT_EQ(reference_scale_double(dreadnought.turn_speed), ft_atol(ship_turn_item->value));
+    json_free_groups(fleet_groups);
+
+    ft_map<int, ft_sharedptr<ft_planet> > restored_planets;
+    FT_ASSERT(saves.deserialize_planets(planet_json.c_str(), restored_planets));
+    Pair<int, ft_sharedptr<ft_planet> > *vulcan_entry = restored_planets.find(PLANET_VULCAN);
+    FT_ASSERT(vulcan_entry != ft_nullptr);
+    double restored_rate = vulcan_entry->value->get_rate(ORE_GOLD);
+    FT_ASSERT(ft_absolute(restored_rate - large_rate) < 0.000001);
+    FT_ASSERT_EQ(large_stock, vulcan_entry->value->get_resource(ORE_GOLD));
+    const ft_vector<Pair<int, double> > &restored_carry = vulcan_entry->value->get_carryover();
+    double carry_value = 0.0;
+    for (size_t i = 0; i < restored_carry.size(); ++i)
+    {
+        if (restored_carry[i].key == ORE_GOLD)
+            carry_value = restored_carry[i].value;
+    }
+    FT_ASSERT(ft_absolute(carry_value - large_carryover) < 0.000001);
+
+    ft_map<int, ft_sharedptr<ft_fleet> > restored_fleets;
+    FT_ASSERT(saves.deserialize_fleets(fleet_json.c_str(), restored_fleets));
+    Pair<int, ft_sharedptr<ft_fleet> > *armada_entry = restored_fleets.find(404);
+    FT_ASSERT(armada_entry != ft_nullptr);
+    FT_ASSERT(ft_absolute(armada_entry->value->get_travel_time() - travel_time) < 0.000001);
+    FT_ASSERT(ft_absolute(armada_entry->value->get_escort_veterancy() - veterancy) < 0.000001);
+    const ft_ship *restored_dreadnought = armada_entry->value->get_ship(9001);
+    FT_ASSERT(restored_dreadnought != ft_nullptr);
+    FT_ASSERT_EQ(dreadnought.armor, restored_dreadnought->armor);
+    FT_ASSERT_EQ(dreadnought.hp, restored_dreadnought->hp);
+    FT_ASSERT_EQ(dreadnought.shield, restored_dreadnought->shield);
+    FT_ASSERT_EQ(dreadnought.max_hp, restored_dreadnought->max_hp);
+    FT_ASSERT_EQ(dreadnought.max_shield, restored_dreadnought->max_shield);
+    FT_ASSERT(ft_absolute(restored_dreadnought->max_speed - dreadnought.max_speed) < 0.000001);
+    FT_ASSERT(ft_absolute(restored_dreadnought->acceleration - dreadnought.acceleration) < 0.000001);
+    FT_ASSERT(ft_absolute(restored_dreadnought->turn_speed - dreadnought.turn_speed) < 0.000001);
+    FT_ASSERT_EQ(dreadnought.combat_behavior, restored_dreadnought->combat_behavior);
+    FT_ASSERT_EQ(dreadnought.outnumbered_behavior, restored_dreadnought->outnumbered_behavior);
+    FT_ASSERT_EQ(dreadnought.unescorted_behavior, restored_dreadnought->unescorted_behavior);
+    FT_ASSERT_EQ(dreadnought.low_hp_behavior, restored_dreadnought->low_hp_behavior);
+    FT_ASSERT_EQ(dreadnought.role, restored_dreadnought->role);
+
+    return 1;
+}
+
+int verify_campaign_checkpoint_flow()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    FT_ASSERT(game.has_campaign_checkpoint());
+    FT_ASSERT(game.get_campaign_planet_checkpoint().size() > 0);
+
+    game.set_ore(PLANET_TERRA, ORE_IRON, 40);
+    game.set_ore(PLANET_TERRA, ORE_COPPER, 30);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 12);
+    game.tick(0.0);
+    FT_ASSERT_EQ(QUEST_STATUS_COMPLETED, game.get_quest_status(QUEST_INITIAL_SKIRMISHES));
+    FT_ASSERT(game.has_campaign_checkpoint());
+    FT_ASSERT(ft_strncmp(game.get_campaign_checkpoint_tag().c_str(), "quest_completed_", 16) == 0);
+
+    game.create_fleet(72);
+    int ship_id = game.create_ship(72, SHIP_SHIELD);
+    FT_ASSERT(ship_id != 0);
+    game.set_ship_hp(72, ship_id, 144);
+    game.set_ship_shield(72, ship_id, 222);
+    game.set_ore(PLANET_TERRA, ORE_IRON, 85);
+    game.save_campaign_checkpoint(ft_string("manual_checkpoint"));
+    FT_ASSERT(game.has_campaign_checkpoint());
+    FT_ASSERT(ft_strcmp(game.get_campaign_checkpoint_tag().c_str(), "manual_checkpoint") == 0);
+
+    game.set_ore(PLANET_TERRA, ORE_IRON, 0);
+    game.remove_fleet(72, -1, -1);
+    FT_ASSERT(game.reload_campaign_checkpoint());
+    FT_ASSERT_EQ(85, game.get_ore(PLANET_TERRA, ORE_IRON));
+    FT_ASSERT(game.get_fleet_location(72).type != 0);
+    FT_ASSERT_EQ(144, game.get_ship_hp(72, ship_id));
+    FT_ASSERT_EQ(222, game.get_ship_shield(72, ship_id));
+
+    return 1;
+}

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -32,5 +32,9 @@ int verify_convoy_escort_travel_speed();
 int verify_achievement_catalog();
 int verify_achievement_progression();
 int verify_quest_achievement_failures();
+int verify_save_system_round_trip();
+int verify_save_system_edge_cases();
+int validate_save_system_serialized_samples();
+int verify_campaign_checkpoint_flow();
 
 #endif


### PR DESCRIPTION
## Summary
- extend the save/load regression file with targeted checks for empty collections and sparse JSON content
- add a harness that serializes large and fractional values to confirm the scaling helpers round-trip fleet and planet data without loss
- register the new regression helpers with the game test driver so they run with the existing suite

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cc13d7df8083318ef0424c753c8793