### PR TITLE
Extend save checkpoints to research and achievements

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ the C++ standard library serializers. Two helpers are currently available:
   assignments, escort veterancy, and all ship statistics. Fleet snapshots use
   stable ship identifiers and scale floating-point values into integers to avoid
   precision loss in JSON.
+- `serialize_research` / `deserialize_research` capture the entire research
+  catalog, including active projects, time remaining, and the global duration
+  scale so campaign pacing matches the moment a save was taken.
+- `serialize_achievements` / `deserialize_achievements` preserve achievement
+  progress and completion flags so lore entries and rewards remain consistent
+  across reloads.
 
 The serializers rely on new accessors such as `ft_planet::get_carryover` and
 `ft_fleet::add_ship_snapshot` so game code can hand the `SaveSystem` concrete

--- a/src/achievements.cpp
+++ b/src/achievements.cpp
@@ -282,3 +282,38 @@ void AchievementManager::get_achievement_ids(ft_vector<int> &out) const
     for (size_t i = 0; i < count; ++i)
         out.push_back(entries[i].key);
 }
+
+void AchievementManager::get_progress_state(ft_map<int, ft_achievement_progress> &out) const
+{
+    out.clear();
+    size_t count = this->_progress.size();
+    if (count == 0)
+        return ;
+    const Pair<int, ft_achievement_progress> *entries = this->_progress.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+        out.insert(entries[i].key, entries[i].value);
+}
+
+bool AchievementManager::set_progress_state(const ft_map<int, ft_achievement_progress> &state)
+{
+    bool applied = false;
+    size_t count = state.size();
+    if (count == 0)
+        return false;
+    const Pair<int, ft_achievement_progress> *entries = state.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        Pair<int, ft_achievement_progress> *existing = this->_progress.find(entries[i].key);
+        if (existing == ft_nullptr)
+            continue;
+        int value = entries[i].value.value;
+        if (value < 0)
+            value = 0;
+        existing->value.value = value;
+        existing->value.completed = entries[i].value.completed;
+        applied = true;
+    }
+    return applied;
+}

--- a/src/achievements.hpp
+++ b/src/achievements.hpp
@@ -107,6 +107,9 @@ public:
     int get_target(int achievement_id) const;
     bool get_info(int achievement_id, ft_achievement_info &out) const;
     void get_achievement_ids(ft_vector<int> &out) const;
+
+    void get_progress_state(ft_map<int, ft_achievement_progress> &out) const;
+    bool set_progress_state(const ft_map<int, ft_achievement_progress> &state);
 };
 
 #endif

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -153,6 +153,8 @@ private:
     int                                          _rebellion_branch_pending_assault;
     ft_string                                    _last_planet_checkpoint;
     ft_string                                    _last_fleet_checkpoint;
+    ft_string                                    _last_research_checkpoint;
+    ft_string                                    _last_achievement_checkpoint;
     ft_string                                    _last_checkpoint_tag;
     bool                                         _has_checkpoint;
 
@@ -350,8 +352,11 @@ public:
     const ft_string &get_campaign_planet_checkpoint() const noexcept;
     const ft_string &get_campaign_fleet_checkpoint() const noexcept;
     const ft_string &get_campaign_checkpoint_tag() const noexcept;
+    const ft_string &get_campaign_research_checkpoint() const noexcept;
+    const ft_string &get_campaign_achievement_checkpoint() const noexcept;
     bool reload_campaign_checkpoint() noexcept;
-    bool load_campaign_from_save(const ft_string &planet_json, const ft_string &fleet_json) noexcept;
+    bool load_campaign_from_save(const ft_string &planet_json, const ft_string &fleet_json,
+                                 const ft_string &research_json, const ft_string &achievement_json) noexcept;
 };
 
 #endif

--- a/src/research.hpp
+++ b/src/research.hpp
@@ -91,6 +91,9 @@ public:
     double get_remaining_time(int research_id) const;
     const ft_research_definition *get_definition(int research_id) const;
     void mark_completed(int research_id);
+
+    void get_progress_state(ft_map<int, ft_research_progress> &out) const;
+    bool set_progress_state(const ft_map<int, ft_research_progress> &state);
 };
 
 #endif

--- a/src/save_system.hpp
+++ b/src/save_system.hpp
@@ -3,6 +3,8 @@
 
 #include "planets.hpp"
 #include "fleets.hpp"
+#include "research.hpp"
+#include "achievements.hpp"
 #include "../libft/JSon/document.hpp"
 #include "../libft/JSon/json.hpp"
 #include "../libft/CPP_class/class_string_class.hpp"
@@ -22,6 +24,12 @@ public:
     ft_string serialize_fleets(const ft_map<int, ft_sharedptr<ft_fleet> > &fleets) const noexcept;
     bool deserialize_fleets(const char *content,
         ft_map<int, ft_sharedptr<ft_fleet> > &fleets) const noexcept;
+
+    ft_string serialize_research(const ResearchManager &research) const noexcept;
+    bool deserialize_research(const char *content, ResearchManager &research) const noexcept;
+
+    ft_string serialize_achievements(const AchievementManager &achievements) const noexcept;
+    bool deserialize_achievements(const char *content, AchievementManager &achievements) const noexcept;
 
 private:
     ft_sharedptr<ft_planet> create_planet_instance(int planet_id) const noexcept;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -94,9 +94,17 @@ int main()
         return 0;
     if (!verify_save_system_edge_cases())
         return 0;
+    if (!verify_save_system_invalid_inputs())
+        return 0;
     if (!validate_save_system_serialized_samples())
         return 0;
+    if (!verify_research_save_round_trip())
+        return 0;
+    if (!verify_achievement_save_round_trip())
+        return 0;
     if (!verify_campaign_checkpoint_flow())
+        return 0;
+    if (!verify_campaign_rejects_invalid_save())
         return 0;
 
     server_thread.join();

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -34,7 +34,11 @@ int verify_achievement_progression();
 int verify_quest_achievement_failures();
 int verify_save_system_round_trip();
 int verify_save_system_edge_cases();
+int verify_save_system_invalid_inputs();
 int validate_save_system_serialized_samples();
+int verify_research_save_round_trip();
+int verify_achievement_save_round_trip();
 int verify_campaign_checkpoint_flow();
+int verify_campaign_rejects_invalid_save();
 
 #endif


### PR DESCRIPTION
## Summary
- capture research and achievement JSON when saving campaign checkpoints and restore managers when loading them
- expose checkpoint accessors for the new research and achievement payloads and keep documentation in sync
- extend the save system regression test to verify research state and achievement progress survive explicit load calls
- add negative test coverage for invalid save payloads and ensure the campaign loader refuses corrupted data without mutating state

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68ccf6d6f2dc833195ba463442d3407c