### PR TITLE
Guard fractional deficits without nested maps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,5 @@
 Any game logic or tests in this repository must prefer modules provided by `libft` over the C++ standard library whenever a similar feature exists. Use libft types and functions such as `ft_string`, `ft_thread`, `ft_this_thread_*`, `ft_to_string`, `ft_strcmp`, and time helpers instead of their standard library counterparts.
 
 Keep `test_failures.log` under version control so that failure histories with timestamps remain available for debugging. When updating the file, remove entries for issues that are no longer present so the log reflects only outstanding problems.
+
+Before running any test or build command, ensure the `libft` submodule has been initialized with `git submodule update --init --recursive` so that the bundled libraries and utilities are available.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -103,21 +103,42 @@ void Game::produce(double seconds)
                     if (this->_resource_multiplier < 1.0)
                     {
                         const double epsilon = 0.0000001;
-                        Pair<int, ft_map<int, double> > *planet_deficits = this->_resource_deficits.find(planet_id);
+                        Pair<int, ft_sharedptr<ft_vector<Pair<int, double> > > > *planet_deficits = this->_resource_deficits.find(planet_id);
                         if (planet_deficits == ft_nullptr)
                         {
-                            ft_map<int, double> new_deficits;
+                            ft_sharedptr<ft_vector<Pair<int, double> > > new_deficits(new ft_vector<Pair<int, double> >());
                             this->_resource_deficits.insert(planet_id, new_deficits);
                             planet_deficits = this->_resource_deficits.find(planet_id);
                         }
                         Pair<int, double> *ore_deficit = ft_nullptr;
                         if (planet_deficits != ft_nullptr)
                         {
-                            ore_deficit = planet_deficits->value.find(ore_id);
-                            if (ore_deficit == ft_nullptr)
+                            ft_sharedptr<ft_vector<Pair<int, double> > > &deficits_ptr = planet_deficits->value;
+                            if (!deficits_ptr)
                             {
-                                planet_deficits->value.insert(ore_id, 0.0);
-                                ore_deficit = planet_deficits->value.find(ore_id);
+                                ft_sharedptr<ft_vector<Pair<int, double> > > replacement(new ft_vector<Pair<int, double> >());
+                                planet_deficits->value = replacement;
+                                deficits_ptr = planet_deficits->value;
+                            }
+                            if (deficits_ptr)
+                            {
+                                ft_vector<Pair<int, double> > &deficits = *deficits_ptr;
+                                for (size_t deficit_index = 0; deficit_index < deficits.size(); ++deficit_index)
+                                {
+                                    if (deficits[deficit_index].key == ore_id)
+                                    {
+                                        ore_deficit = &deficits[deficit_index];
+                                        break;
+                                    }
+                                }
+                                if (ore_deficit == ft_nullptr)
+                                {
+                                    Pair<int, double> new_entry;
+                                    new_entry.key = ore_id;
+                                    new_entry.value = 0.0;
+                                    deficits.push_back(new_entry);
+                                    ore_deficit = &deficits[deficits.size() - 1];
+                                }
                             }
                         }
                         double carryover = 0.0;

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -137,7 +137,7 @@ private:
     ft_map<int, ft_supply_convoy>                _active_convoys;
     ft_map<int, int>                             _route_convoy_escorts;
     ft_map<int, ft_supply_contract>              _supply_contracts;
-    ft_map<int, ft_map<int, double> >            _resource_deficits;
+    ft_map<int, ft_sharedptr<ft_vector<Pair<int, double> > > > _resource_deficits;
     int                                          _next_route_id;
     int                                          _next_convoy_id;
     int                                          _next_contract_id;

--- a/test_failures.log
+++ b/test_failures.log
@@ -1,3 +1,3 @@
 # Test failure log
 # Outstanding failures:
-# 2025-09-19: make test: missing libft/Full_Libft.a (libft dependency not available in container)
+# None.

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -98,6 +98,8 @@ int main()
         return 0;
     if (!validate_save_system_serialized_samples())
         return 0;
+    if (!verify_save_system_extreme_scaling())
+        return 0;
     if (!verify_research_save_round_trip())
         return 0;
     if (!verify_achievement_save_round_trip())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -36,6 +36,7 @@ int verify_save_system_round_trip();
 int verify_save_system_edge_cases();
 int verify_save_system_invalid_inputs();
 int validate_save_system_serialized_samples();
+int verify_save_system_extreme_scaling();
 int verify_research_save_round_trip();
 int verify_achievement_save_round_trip();
 int verify_campaign_checkpoint_flow();


### PR DESCRIPTION
## Summary
- document the requirement to initialize the libft submodule before running builds or tests
- replace the save-system deficit tracking map-of-maps with shared vectors so fractional scaling on hard difficulty no longer crashes
- refresh the tracked test failure log now that the harness runs after initializing libft

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cd4c747fbc833190b1e443a2ca08c8