### PR TITLE
Propagate checkpoint save failure status

### DIFF
--- a/src/game.hpp
+++ b/src/game.hpp
@@ -157,6 +157,8 @@ private:
     ft_string                                    _last_achievement_checkpoint;
     ft_string                                    _last_checkpoint_tag;
     bool                                         _has_checkpoint;
+    ft_vector<ft_string>                         _failed_checkpoint_tags;
+    bool                                         _force_checkpoint_failure;
     bool                                         _backend_online;
 
     ft_sharedptr<ft_planet> get_planet(int id);
@@ -222,7 +224,8 @@ private:
     void trigger_branch_assault(int planet_id, double difficulty, bool order_branch);
     void apply_planet_snapshot(const ft_map<int, ft_sharedptr<ft_planet> > &snapshot);
     void apply_fleet_snapshot(const ft_map<int, ft_sharedptr<ft_fleet> > &snapshot);
-    void checkpoint_campaign_state_internal(const ft_string &tag);
+    bool checkpoint_campaign_state_internal(const ft_string &tag);
+    void record_checkpoint_failure(const ft_string &tag) noexcept;
 
 public:
     Game(const ft_string &host, const ft_string &path, int difficulty = GAME_DIFFICULTY_STANDARD);
@@ -349,7 +352,9 @@ public:
     int get_planet_fleet_ship_hp(int planet_id, int ship_uid) const;
     ft_location get_planet_fleet_location(int planet_id) const;
 
-    void save_campaign_checkpoint(const ft_string &tag) noexcept;
+    bool save_campaign_checkpoint(const ft_string &tag) noexcept;
+    const ft_vector<ft_string> &get_failed_checkpoint_tags() const noexcept;
+    void set_force_checkpoint_failure(bool enabled) noexcept;
     bool has_campaign_checkpoint() const noexcept;
     const ft_string &get_campaign_planet_checkpoint() const noexcept;
     const ft_string &get_campaign_fleet_checkpoint() const noexcept;

--- a/src/game_quests.cpp
+++ b/src/game_quests.cpp
@@ -182,7 +182,8 @@ void Game::handle_quest_completion(int quest_id)
     this->record_quest_achievement(quest_id);
     ft_string tag("quest_completed_");
     tag.append(ft_to_string(quest_id));
-    this->save_campaign_checkpoint(tag);
+    if (!this->save_campaign_checkpoint(tag))
+        return ;
 }
 
 void Game::handle_quest_failure(int quest_id)

--- a/src/game_research.cpp
+++ b/src/game_research.cpp
@@ -117,7 +117,8 @@ void Game::handle_research_completion(int research_id)
         this->update_combat_modifiers();
     ft_string tag("research_completed_");
     tag.append(ft_to_string(research_id));
-    this->save_campaign_checkpoint(tag);
+    if (!this->save_campaign_checkpoint(tag))
+        return ;
 }
 
 bool Game::can_start_research(int research_id) const


### PR DESCRIPTION
## Summary
- make `Game::checkpoint_campaign_state_internal` report success and add tracking for failed checkpoint attempts
- return the success flag from `Game::save_campaign_checkpoint`, expose helpers for tests, and check the result at quest/research call sites
- extend the save/load tests to assert the success path and cover a simulated checkpoint failure

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cd5aade53883319e13bb9b473b9b8a