### PR TITLE
Handle serialization allocation failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ make
 The tests start a minimal HTTP server provided by `libft`, send a POST request through the backend
 client, and verify simple resource mining logic.
 
+Serialization checkpoints now guard against allocation failures inside the JSON helpers. The
+`verify_save_system_allocation_failures` test simulates failed group and item creation to confirm the
+save system aborts cleanly and reports the error back to the checkpoint flow.
+
 ## Game State
 
 The core `ft_game_state` spawns planetary characters for Terra, Mars, Zalthor,

--- a/src/save_system.hpp
+++ b/src/save_system.hpp
@@ -17,6 +17,8 @@ public:
     SaveSystem() noexcept;
     ~SaveSystem() noexcept;
 
+    typedef bool (*json_allocation_hook_t)(const char *type, const char *identifier);
+
     ft_string serialize_planets(const ft_map<int, ft_sharedptr<ft_planet> > &planets) const noexcept;
     bool deserialize_planets(const char *content,
         ft_map<int, ft_sharedptr<ft_planet> > &planets) const noexcept;
@@ -30,6 +32,8 @@ public:
 
     ft_string serialize_achievements(const AchievementManager &achievements) const noexcept;
     bool deserialize_achievements(const char *content, AchievementManager &achievements) const noexcept;
+
+    static void set_json_allocation_hook(json_allocation_hook_t hook) noexcept;
 
 private:
     ft_sharedptr<ft_planet> create_planet_instance(int planet_id) const noexcept;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -98,6 +98,8 @@ int main()
         return 0;
     if (!validate_save_system_serialized_samples())
         return 0;
+    if (!verify_save_system_allocation_failures())
+        return 0;
     if (!verify_save_system_extreme_scaling())
         return 0;
     if (!verify_research_save_round_trip())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -36,6 +36,7 @@ int verify_save_system_round_trip();
 int verify_save_system_edge_cases();
 int verify_save_system_invalid_inputs();
 int validate_save_system_serialized_samples();
+int verify_save_system_allocation_failures();
 int verify_save_system_extreme_scaling();
 int verify_research_save_round_trip();
 int verify_achievement_save_round_trip();


### PR DESCRIPTION
## Summary
- add a JSON allocation hook and helper routines so SaveSystem serialization aborts and clears intermediate state when group or item creation fails
- propagate the failure from planets, fleets, research, and achievements serialization loops by returning empty output on any allocation error
- document the new behavior and extend the test suite with allocation-failure hooks plus a dedicated regression test wired into the main harness

## Testing
- make
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cd5da296088331a3f7bea3fff36404