### PR TITLE
Accumulate mine bonuses across ticks

### DIFF
--- a/src/game.hpp
+++ b/src/game.hpp
@@ -137,7 +137,17 @@ private:
     ft_map<int, ft_supply_convoy>                _active_convoys;
     ft_map<int, int>                             _route_convoy_escorts;
     ft_map<int, ft_supply_contract>              _supply_contracts;
-    ft_map<int, ft_sharedptr<ft_vector<Pair<int, double> > > > _resource_deficits;
+    struct ft_resource_accumulator
+    {
+        double multiplier_deficit;
+        double mine_bonus_remainder;
+
+        ft_resource_accumulator()
+            : multiplier_deficit(0.0), mine_bonus_remainder(0.0)
+        {}
+    };
+
+    ft_map<int, ft_sharedptr<ft_vector<Pair<int, ft_resource_accumulator> > > > _resource_deficits;
     int                                          _next_route_id;
     int                                          _next_convoy_id;
     int                                          _next_contract_id;
@@ -168,6 +178,7 @@ private:
     ft_sharedptr<ft_fleet> get_planet_fleet(int id);
     ft_sharedptr<const ft_fleet> get_planet_fleet(int id) const;
     void send_state(int planet_id, int ore_id);
+    Pair<int, ft_resource_accumulator> *get_resource_accumulator(int planet_id, int ore_id, bool create);
     void unlock_planet(int planet_id);
     bool can_pay_research_cost(const ft_vector<Pair<int, int> > &costs) const;
     void pay_research_cost(const ft_vector<Pair<int, int> > &costs);

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -119,6 +119,45 @@ int verify_hard_difficulty_fractional_output()
     return 1;
 }
 
+int verify_mine_upgrade_station_bonus()
+{
+    const int planet_id = PLANET_TERRA;
+    const int ore_id = ORE_IRON;
+
+    Game baseline(ft_string("127.0.0.1:8080"), ft_string("/"));
+    baseline.set_ore(planet_id, ore_id, 0);
+    baseline.set_ore(planet_id, ORE_COPPER, 0);
+    baseline.set_ore(planet_id, ORE_COAL, 0);
+
+    Game upgraded(ft_string("127.0.0.1:8080"), ft_string("/"));
+    upgraded.ensure_planet_item_slot(planet_id, ORE_MITHRIL);
+    upgraded.set_ore(planet_id, ore_id, 20);
+    upgraded.set_ore(planet_id, ORE_MITHRIL, 4);
+    FT_ASSERT(upgraded.place_building(planet_id, BUILDING_UPGRADE_STATION, 1, 0) != 0);
+    upgraded.tick(0.0);
+    upgraded.set_ore(planet_id, ore_id, 0);
+    upgraded.set_ore(planet_id, ORE_COPPER, 0);
+    upgraded.set_ore(planet_id, ORE_COAL, 0);
+    upgraded.set_ore(planet_id, ORE_MITHRIL, 0);
+
+    const int tick_count = 240;
+    for (int i = 0; i < tick_count; ++i)
+        baseline.produce(1.0);
+    for (int i = 0; i < tick_count; ++i)
+        upgraded.produce(1.0);
+
+    int baseline_output = baseline.get_ore(planet_id, ore_id);
+    int upgraded_output = upgraded.get_ore(planet_id, ore_id);
+    FT_ASSERT(baseline_output > 0);
+    FT_ASSERT(upgraded_output > baseline_output);
+
+    double ratio = static_cast<double>(upgraded_output) / static_cast<double>(baseline_output);
+    FT_ASSERT(ratio > 1.13);
+    FT_ASSERT(ratio < 1.17);
+
+    return 1;
+}
+
 int verify_supply_route_key_collisions()
 {
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -29,6 +29,9 @@ int main()
     if (!verify_hard_difficulty_fractional_output())
         return 0;
 
+    if (!verify_mine_upgrade_station_bonus())
+        return 0;
+
     if (!verify_supply_route_key_collisions())
         return 0;
 

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -26,6 +26,7 @@ int verify_crafting_and_energy_research();
 int verify_auxiliary_and_escape_protocol();
 int verify_fractional_resource_accumulation();
 int verify_hard_difficulty_fractional_output();
+int verify_mine_upgrade_station_bonus();
 int verify_supply_route_key_collisions();
 int verify_trade_relay_convoy_modifiers();
 int verify_convoy_escort_travel_speed();


### PR DESCRIPTION
## Summary
- extend the game resource accumulator map so each planet/resource keeps both multiplier deficits and mine bonus remainders
- apply stored mine bonus fractions in `Game::produce` via a helper that fetches the per-ore accumulator
- add a regression test that places a Mine Upgrade Station and checks average production climbs by about 15%

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cd6e3322cc83318cc32b0eead454e5