### PR TITLE
Improve backend HTTP status handling

### DIFF
--- a/src/backend_client.cpp
+++ b/src/backend_client.cpp
@@ -1,4 +1,35 @@
 #include "backend_client.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+#include "../libft/Libft/libft.hpp"
+
+namespace
+{
+    int extract_http_status_code(const ft_string &response)
+    {
+        const char *cstr = response.c_str();
+        const char *http_prefix = "HTTP/";
+        const size_t prefix_size = 5;
+
+        if (response.size() < prefix_size || ft_strncmp(cstr, http_prefix, prefix_size) != 0)
+            return 0;
+        const char *first_space = ft_strchr(cstr, ' ');
+        if (first_space == ft_nullptr)
+            return 0;
+        const char *status_start = first_space + 1;
+        const char *status_end = ft_strchr(status_start, ' ');
+        size_t token_length;
+        if (status_end == ft_nullptr)
+            token_length = static_cast<size_t>(ft_strlen(status_start));
+        else
+            token_length = static_cast<size_t>(status_end - status_start);
+        char status_buffer[16];
+        if (token_length == 0 || token_length >= sizeof(status_buffer))
+            return 0;
+        ft_memcpy(status_buffer, status_start, token_length);
+        status_buffer[token_length] = '\0';
+        return ft_atoi(status_buffer);
+    }
+}
 
 BackendClient::BackendClient(const ft_string &host, const ft_string &path)
     : _host(host), _path(path)
@@ -14,12 +45,26 @@ BackendClient::~BackendClient()
 int BackendClient::send_state(const ft_string &state, ft_string &response)
 {
     int status = http_post(this->_host.c_str(), this->_path.c_str(), state, response, false);
+    bool transport_failure = (status != 0);
+    int http_status = 0;
 
-    if (status != 0 || response.size() == 0)
+    if (!transport_failure)
+    {
+        http_status = extract_http_status_code(response);
+        if (http_status >= 200 && http_status < 300)
+            return (http_status);
+        if (http_status == 0)
+            transport_failure = true;
+    }
+    if (transport_failure || http_status < 200 || http_status >= 400)
     {
         ft_string fallback_prefix("[offline] echo=");
         fallback_prefix.append(state);
         response = fallback_prefix;
+        if (!transport_failure && http_status != 0)
+            return (http_status);
     }
+    if (!transport_failure)
+        return (http_status);
     return (status);
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -386,7 +386,7 @@ void Game::send_state(int planet_id, int ore_id)
     body.append("}");
     ft_string response;
     int status = this->_backend.send_state(body, response);
-    bool offline = (status != 0);
+    bool offline = (status < 200 || status >= 400);
     if (!offline)
     {
         const ft_string fallback_prefix("[offline] echo=");

--- a/test_failures.log
+++ b/test_failures.log
@@ -1,4 +1,3 @@
 # Test failure log
 # Outstanding failures:
 # None.
-tests/game_test_backend.cpp:53: online_game.is_backend_online() (observed 2025-09-19T15:30:02Z)


### PR DESCRIPTION
## Summary
- parse HTTP status codes in the backend client so transport failures and non-success codes trigger the offline echo while 2xx responses stay intact
- update the game-side backend status tracking to rely on the revised success range
- clear the resolved backend failure entry from the shared test failure log

## Testing
- `make test`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_68ce3bcbd0788331a286c41fc6e5d6ee