### PR TITLE
Fix building pause handling and add resume delay test

### DIFF
--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -579,7 +579,8 @@ void BuildingManager::tick_planet(Game &game, ft_planet_build_state &state, doub
         }
         if (!can_run)
         {
-            instance.progress = definition->cycle_time;
+            if (instance.progress > definition->cycle_time)
+                instance.progress = definition->cycle_time;
             continue;
         }
         instance.active = true;

--- a/test_failures.log
+++ b/test_failures.log
@@ -1,3 +1,3 @@
 # Test failure log
 # Outstanding failures:
-# None.
+tests/game_test_backend.cpp:53: online_game.is_backend_online()

--- a/tests/game_test_energy.cpp
+++ b/tests/game_test_energy.cpp
@@ -124,6 +124,37 @@ int compare_energy_pressure_scenarios()
     return 1;
 }
 
+int verify_crafting_resume_requires_full_cycle()
+{
+    Game production_game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    production_game.set_ore(PLANET_TERRA, ORE_IRON, 200);
+    production_game.set_ore(PLANET_TERRA, ORE_COPPER, 200);
+    production_game.set_ore(PLANET_TERRA, ORE_COAL, 200);
+    production_game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 10);
+    production_game.set_ore(PLANET_TERRA, ITEM_COPPER_BAR, 10);
+    production_game.set_ore(PLANET_TERRA, ITEM_ENGINE_PART, 0);
+
+    FT_ASSERT(production_game.place_building(PLANET_TERRA, BUILDING_POWER_GENERATOR, 2, 0) != 0);
+    FT_ASSERT(production_game.place_building(PLANET_TERRA, BUILDING_CRAFTING_BAY, 0, 2) != 0);
+    production_game.tick(1.0);
+
+    int initial_parts = production_game.get_ore(PLANET_TERRA, ITEM_ENGINE_PART);
+    FT_ASSERT_EQ(0, initial_parts);
+
+    FT_ASSERT(production_game.place_building(PLANET_TERRA, BUILDING_CONVEYOR, 3, 2) != 0);
+
+    production_game.tick(0.0);
+    FT_ASSERT_EQ(initial_parts, production_game.get_ore(PLANET_TERRA, ITEM_ENGINE_PART));
+
+    production_game.tick(7.5);
+    FT_ASSERT_EQ(initial_parts, production_game.get_ore(PLANET_TERRA, ITEM_ENGINE_PART));
+
+    production_game.tick(1.0);
+    int after_resume = production_game.get_ore(PLANET_TERRA, ITEM_ENGINE_PART);
+    FT_ASSERT(after_resume >= initial_parts + 1);
+    return 1;
+}
+
 int compare_storyline_assaults()
 {
     Game early_game(ft_string("127.0.0.1:8080"), ft_string("/"));

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -73,6 +73,8 @@ int main()
 
     if (!compare_energy_pressure_scenarios())
         return 0;
+    if (!verify_crafting_resume_requires_full_cycle())
+        return 0;
     if (!compare_storyline_assaults())
         return 0;
     if (!analyze_manual_vs_auto_assault_controls())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -14,6 +14,7 @@ int verify_multiple_convoy_raids();
 int verify_supply_route_escalation();
 int verify_escort_veterancy_progression();
 int compare_energy_pressure_scenarios();
+int verify_crafting_resume_requires_full_cycle();
 int compare_storyline_assaults();
 int analyze_manual_vs_auto_assault_controls();
 int measure_assault_aggression_effects();


### PR DESCRIPTION
## Summary
- ensure paused buildings preserve their accumulated progress instead of jumping to a finished cycle
- add a crafting regression test that requires a full cycle after restoring logistics before production resumes
- document the persistent backend connectivity failure in `test_failures.log`

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68ce45ee0dc48331a0279d9865951797