### PR TITLE
Ensure set_ore allocates missing resource slots

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -666,6 +666,7 @@ void Game::set_ore(int planet_id, int ore_id, int amount)
     ft_sharedptr<ft_planet> planet = this->get_planet(planet_id);
     if (!planet)
         return ;
+    this->ensure_planet_item_slot(planet_id, ore_id);
     planet->set_resource(ore_id, amount);
     this->send_state(planet_id, ore_id);
 }

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -158,6 +158,25 @@ int verify_mine_upgrade_station_bonus()
     return 1;
 }
 
+int verify_set_ore_creates_missing_resource()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    const int planet_id = PLANET_TERRA;
+    const int resource_id = ORE_TRITIUM;
+
+    FT_ASSERT_EQ(0, game.get_ore(planet_id, resource_id));
+
+    const int first_amount = 37;
+    game.set_ore(planet_id, resource_id, first_amount);
+    FT_ASSERT_EQ(first_amount, game.get_ore(planet_id, resource_id));
+
+    const int second_amount = 12;
+    game.set_ore(planet_id, resource_id, second_amount);
+    FT_ASSERT_EQ(second_amount, game.get_ore(planet_id, resource_id));
+
+    return 1;
+}
+
 int verify_supply_route_key_collisions()
 {
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -32,6 +32,9 @@ int main()
     if (!verify_mine_upgrade_station_bonus())
         return 0;
 
+    if (!verify_set_ore_creates_missing_resource())
+        return 0;
+
     if (!verify_supply_route_key_collisions())
         return 0;
 

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -30,6 +30,7 @@ int verify_auxiliary_and_escape_protocol();
 int verify_fractional_resource_accumulation();
 int verify_hard_difficulty_fractional_output();
 int verify_mine_upgrade_station_bonus();
+int verify_set_ore_creates_missing_resource();
 int verify_supply_route_key_collisions();
 int verify_trade_relay_convoy_modifiers();
 int verify_convoy_escort_travel_speed();


### PR DESCRIPTION
## Summary
- ensure `Game::set_ore` creates a missing resource slot before assigning the amount
- add a regression test that sets an unregistered resource and hook it into the backend test suite

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68ce4adcb8508331a5fbd918d7c89ac8