### PR TITLE
Handle oversized ship IDs in fleet loading

### DIFF
--- a/src/fleets.cpp
+++ b/src/fleets.cpp
@@ -1,5 +1,6 @@
 #include "fleets.hpp"
 #include "../libft/Template/vector.hpp"
+#include "../libft/Libft/limits.hpp"
 
 namespace
 {
@@ -392,7 +393,18 @@ void ft_fleet::add_ship_snapshot(const ft_ship &ship) noexcept
 {
     this->_ships.insert(ship.id, ship);
     if (ship.id >= _next_ship_id)
-        _next_ship_id = ship.id + 1;
+    {
+        if (ship.id >= FT_INT_MAX)
+            _next_ship_id = FT_INT_MAX;
+        else
+        {
+            int next_id = ship.id + 1;
+            if (next_id <= ship.id)
+                _next_ship_id = FT_INT_MAX;
+            else
+                _next_ship_id = next_id;
+        }
+    }
 }
 
 void ft_fleet::remove_ship(int ship_uid) noexcept

--- a/src/save_system.cpp
+++ b/src/save_system.cpp
@@ -1,19 +1,20 @@
 #include "save_system.hpp"
 #include "../libft/CMA/CMA.hpp"
 #include "../libft/CPP_class/class_nullptr.hpp"
-
-#include <climits>
+#include "../libft/Libft/limits.hpp"
 #include <cmath>
 #include <limits>
 
 namespace
 {
     const long SAVE_DOUBLE_SCALE = 1000000;
-    const long SAVE_DOUBLE_SENTINEL_NAN = LONG_MIN;
-    const long SAVE_DOUBLE_SENTINEL_NEG_INF = LONG_MIN + 1;
-    const long SAVE_DOUBLE_SENTINEL_POS_INF = LONG_MAX;
-    const long SAVE_DOUBLE_MIN_FINITE = LONG_MIN + 2;
-    const long SAVE_DOUBLE_MAX_FINITE = LONG_MAX - 1;
+    const long SAVE_DOUBLE_SENTINEL_NAN = FT_LONG_MIN;
+    const long SAVE_DOUBLE_SENTINEL_NEG_INF = FT_LONG_MIN + 1;
+    const long SAVE_DOUBLE_SENTINEL_POS_INF = FT_LONG_MAX;
+    const long SAVE_DOUBLE_MIN_FINITE = FT_LONG_MIN + 2;
+    const long SAVE_DOUBLE_MAX_FINITE = FT_LONG_MAX - 1;
+    const int  SAVE_SHIP_ID_MIN = 1;
+    const int  SAVE_SHIP_ID_MAX = FT_INT_MAX - 1;
 
     SaveSystem::json_allocation_hook_t g_json_allocation_hook = ft_nullptr;
 
@@ -505,6 +506,12 @@ bool SaveSystem::deserialize_fleets(const char *content,
                 continue;
             ft_ship ship_snapshot;
             ship_snapshot.id = ft_atoi(ship_id_item->value);
+            if (ship_snapshot.id < SAVE_SHIP_ID_MIN
+                || ship_snapshot.id > SAVE_SHIP_ID_MAX)
+            {
+                json_free_groups(groups);
+                return false;
+            }
             key = base_key;
             key.append("_type");
             json_item *ship_type_item = json_find_item(current, key.c_str());

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -108,6 +108,8 @@ int main()
         return 0;
     if (!verify_save_system_invalid_inputs())
         return 0;
+    if (!verify_save_system_rejects_overlarge_ship_ids())
+        return 0;
     if (!validate_save_system_serialized_samples())
         return 0;
     if (!verify_save_system_allocation_failures())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -40,6 +40,7 @@ int verify_quest_achievement_failures();
 int verify_save_system_round_trip();
 int verify_save_system_edge_cases();
 int verify_save_system_invalid_inputs();
+int verify_save_system_rejects_overlarge_ship_ids();
 int validate_save_system_serialized_samples();
 int verify_save_system_allocation_failures();
 int verify_save_system_extreme_scaling();


### PR DESCRIPTION
## Summary
- add save-system bounds checks to reject invalid ship IDs during fleet deserialization
- clamp ft_fleet::add_ship_snapshot when ship IDs approach INT_MAX to prevent generator overflow
- extend the save/load test suite to cover oversized ship IDs and register the new check with the test runner
- switch save system, fleet logic, and regression tests to libft limit constants instead of `<climits>`

## Testing
- `make test`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_68ce531b0d5083319a9dede32e3b9954