### PR TITLE
Fix planet inventory restore from snapshots

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -741,11 +741,13 @@ void Game::apply_planet_snapshot(const ft_map<int, ft_sharedptr<ft_planet> > &sn
         const ft_vector<Pair<int, double> > &saved_carryover = saved_planet->get_carryover();
         for (size_t j = 0; j < saved_carryover.size(); ++j)
             planet->set_carryover(saved_carryover[j].key, saved_carryover[j].value);
-        for (size_t j = 0; j < saved_rates.size(); ++j)
+        ft_vector<Pair<int, int> > inventory_snapshot = saved_planet->get_items_snapshot();
+        for (size_t j = 0; j < inventory_snapshot.size(); ++j)
         {
-            int ore_id = saved_rates[j].key;
-            planet->set_resource(ore_id, saved_planet->get_resource(ore_id));
-            this->send_state(planet_id, ore_id);
+            int item_id = inventory_snapshot[j].key;
+            this->ensure_planet_item_slot(planet_id, item_id);
+            planet->set_resource(item_id, inventory_snapshot[j].value);
+            this->send_state(planet_id, item_id);
         }
         this->_resource_deficits.remove(planet_id);
     }

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -122,6 +122,8 @@ int main()
         return 0;
     if (!verify_save_system_sparse_entries())
         return 0;
+    if (!verify_planet_inventory_save_round_trip())
+        return 0;
     if (!verify_building_save_round_trip())
         return 0;
     if (!verify_research_save_round_trip())

--- a/tests/game_test_save.cpp
+++ b/tests/game_test_save.cpp
@@ -1280,6 +1280,37 @@ int verify_save_system_sparse_entries()
     return 1;
 }
 
+int verify_planet_inventory_save_round_trip()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+
+    game.ensure_planet_item_slot(PLANET_TERRA, ITEM_FUSION_REACTOR);
+    game.ensure_planet_item_slot(PLANET_TERRA, ITEM_ADVANCED_ENGINE_PART);
+    game.set_ore(PLANET_TERRA, ORE_IRON, 135);
+    game.set_ore(PLANET_TERRA, ITEM_FUSION_REACTOR, 7);
+    game.set_ore(PLANET_TERRA, ITEM_ADVANCED_ENGINE_PART, 11);
+
+    FT_ASSERT(game.save_campaign_checkpoint(ft_string("inventory_roundtrip")));
+    ft_string planet_json = game.get_campaign_planet_checkpoint();
+    ft_string fleet_json = game.get_campaign_fleet_checkpoint();
+    ft_string research_json = game.get_campaign_research_checkpoint();
+    ft_string achievement_json = game.get_campaign_achievement_checkpoint();
+    ft_string building_json = game.get_campaign_building_checkpoint();
+
+    game.set_ore(PLANET_TERRA, ORE_IRON, 0);
+    game.set_ore(PLANET_TERRA, ITEM_FUSION_REACTOR, 0);
+    game.set_ore(PLANET_TERRA, ITEM_ADVANCED_ENGINE_PART, 0);
+
+    FT_ASSERT(game.load_campaign_from_save(planet_json, fleet_json, research_json,
+        achievement_json, building_json));
+
+    FT_ASSERT_EQ(135, game.get_ore(PLANET_TERRA, ORE_IRON));
+    FT_ASSERT_EQ(7, game.get_ore(PLANET_TERRA, ITEM_FUSION_REACTOR));
+    FT_ASSERT_EQ(11, game.get_ore(PLANET_TERRA, ITEM_ADVANCED_ENGINE_PART));
+
+    return 1;
+}
+
 int verify_building_save_round_trip()
 {
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -47,6 +47,7 @@ int verify_save_system_allocation_failures();
 int verify_save_system_extreme_scaling();
 int verify_save_system_massive_payload();
 int verify_save_system_sparse_entries();
+int verify_planet_inventory_save_round_trip();
 int verify_building_save_round_trip();
 int verify_research_save_round_trip();
 int verify_achievement_save_round_trip();


### PR DESCRIPTION
## Summary
- ensure `Game::apply_planet_snapshot` restores each saved inventory stack and notifies the backend for the affected resources
- add a save/load regression test that seeds planet inventory, reloads from the snapshot, and checks that item counts persist
- wire the new regression into the save-system test harness declarations and runner

## Testing
- `make test`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_68cee7c8dad08331bb9f617f6391d717