### PR TITLE
Add grid size guards to building deserialization

### DIFF
--- a/src/save_system.cpp
+++ b/src/save_system.cpp
@@ -14,6 +14,7 @@ namespace
     const int  SAVE_SHIP_ID_MIN = 1;
     const int  SAVE_SHIP_ID_MAX = FT_INT_MAX - 1;
     const int  SAVE_MAX_SHIPS_PER_FLEET = 4096;
+    const long BUILDING_GRID_MAX_CELLS = 1048576;
 
     union save_system_double_converter
     {
@@ -1237,6 +1238,20 @@ bool SaveSystem::deserialize_buildings(const char *content, BuildingManager &bui
                 state.width = 0;
             if (state.height < 0)
                 state.height = 0;
+
+            size_t sanitized_width = static_cast<size_t>(state.width);
+            size_t sanitized_height = static_cast<size_t>(state.height);
+            size_t max_cells_limit = static_cast<size_t>(BUILDING_GRID_MAX_CELLS);
+            if (sanitized_width > max_cells_limit || sanitized_height > max_cells_limit)
+            {
+                json_free_groups(groups);
+                return false;
+            }
+            if (sanitized_width > 0 && sanitized_height > max_cells_limit / sanitized_width)
+            {
+                json_free_groups(groups);
+                return false;
+            }
             if (state.base_logistic < 0)
                 state.base_logistic = 0;
             if (state.research_logistic_bonus < 0)

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -108,6 +108,8 @@ int main()
         return 0;
     if (!verify_save_system_invalid_inputs())
         return 0;
+    if (!verify_save_system_rejects_oversized_building_grids())
+        return 0;
     if (!verify_save_system_rejects_overlarge_ship_ids())
         return 0;
     if (!verify_save_system_limits_inflated_ship_counts())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -40,6 +40,7 @@ int verify_quest_achievement_failures();
 int verify_save_system_round_trip();
 int verify_save_system_edge_cases();
 int verify_save_system_invalid_inputs();
+int verify_save_system_rejects_oversized_building_grids();
 int verify_save_system_rejects_overlarge_ship_ids();
 int verify_save_system_limits_inflated_ship_counts();
 int validate_save_system_serialized_samples();


### PR DESCRIPTION
## Summary
- define a BUILDING_GRID_MAX_CELLS safeguard and bail out of building deserialization when a save requests an oversized grid
- add a helper for building save payloads and a regression test that exercises wide, tall, and overlarge grids as well as valid clamping behavior
- wire the new test into the save system suite so the oversized grid regression runs with the rest of the harness

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cef05858b08331a725bbbeacefd1e7