### PR TITLE
Normalize loaded planet resources and expand tests

### DIFF
--- a/src/planets.cpp
+++ b/src/planets.cpp
@@ -1,4 +1,18 @@
 #include "planets.hpp"
+#include "../libft/Math/math.hpp"
+
+namespace
+{
+    static bool planet_is_finite(double value) noexcept
+    {
+        if (math_isnan(value))
+            return false;
+        double difference = value - value;
+        if (math_isnan(difference))
+            return false;
+        return true;
+    }
+}
 
 ft_planet::ft_planet(int id) noexcept : _id(id)
 {
@@ -189,6 +203,8 @@ ft_vector<Pair<int, int> > ft_planet::produce(double seconds) noexcept
     {
         int ore_id = this->_rates[i].key;
         double rate = this->_rates[i].value;
+        if (!planet_is_finite(rate))
+            rate = 0.0;
         Pair<int, double> *carry = this->find_carryover(ore_id);
         if (carry == ft_nullptr)
         {
@@ -198,9 +214,17 @@ ft_vector<Pair<int, int> > ft_planet::produce(double seconds) noexcept
             this->_carryover.push_back(entry);
             carry = this->find_carryover(ore_id);
         }
+        if (carry && !planet_is_finite(carry->value))
+            carry->value = 0.0;
         double total = rate * seconds;
+        if (!planet_is_finite(total))
+            total = 0.0;
         if (carry)
+        {
             total += carry->value;
+            if (!planet_is_finite(total))
+                total = 0.0;
+        }
         int amount = static_cast<int>(total + epsilon);
         double remainder = total - static_cast<double>(amount);
         if (remainder < 0.0)

--- a/src/save_system.cpp
+++ b/src/save_system.cpp
@@ -374,6 +374,8 @@ bool SaveSystem::deserialize_planets(const char *content,
         {
             int ore_id = resource_rates[i].key;
             double rate = this->unscale_long_to_double(resource_rates[i].value);
+            if (!save_system_is_finite(rate))
+                rate = 0.0;
             planet->register_resource(ore_id, rate);
         }
         for (size_t i = 0; i < resource_amounts.size(); ++i)
@@ -386,6 +388,8 @@ bool SaveSystem::deserialize_planets(const char *content,
         {
             int ore_id = resource_carryover[i].key;
             double carry_value = this->unscale_long_to_double(resource_carryover[i].value);
+            if (!save_system_is_finite(carry_value))
+                carry_value = 0.0;
             planet->set_carryover(ore_id, carry_value);
         }
         for (size_t i = 0; i < inventory_items.size(); ++i)

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -120,6 +120,8 @@ int main()
         return 0;
     if (!verify_save_system_extreme_scaling())
         return 0;
+    if (!verify_save_system_normalizes_non_finite_planet_values())
+        return 0;
     if (!verify_save_system_massive_payload())
         return 0;
     if (!verify_save_system_sparse_entries())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -46,6 +46,7 @@ int verify_save_system_limits_inflated_ship_counts();
 int validate_save_system_serialized_samples();
 int verify_save_system_allocation_failures();
 int verify_save_system_extreme_scaling();
+int verify_save_system_normalizes_non_finite_planet_values();
 int verify_save_system_massive_payload();
 int verify_save_system_sparse_entries();
 int verify_planet_inventory_save_round_trip();


### PR DESCRIPTION
## Summary
- sanitize non-finite resource rates and carryover values when loading planets and during production so they no longer feed UB paths
- extend the save/load regression suite to cover NaN and infinity inputs and assert that normalized values are produced

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cef5479a708331aebe007fcbbe1c02