### PR TITLE
Protect building manager state during failed loads

### DIFF
--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -3,6 +3,73 @@
 #include "research.hpp"
 #include "../libft/Libft/libft.hpp"
 
+void BuildingManager::clone_from(const BuildingManager &other)
+{
+    if (this == &other)
+        return ;
+    this->_crafting_energy_multiplier = other._crafting_energy_multiplier;
+    this->_crafting_speed_multiplier = other._crafting_speed_multiplier;
+    this->_global_energy_multiplier = other._global_energy_multiplier;
+    this->_building_unlocks.clear();
+    size_t unlock_count = other._building_unlocks.size();
+    if (unlock_count > 0)
+    {
+        const Pair<int, bool> *unlock_entries = other._building_unlocks.end();
+        unlock_entries -= unlock_count;
+        for (size_t i = 0; i < unlock_count; ++i)
+            this->_building_unlocks.insert(unlock_entries[i].key, unlock_entries[i].value);
+    }
+    this->_planets.clear();
+    size_t planet_count = other._planets.size();
+    if (planet_count == 0)
+        return ;
+    const Pair<int, ft_planet_build_state> *entries = other._planets.end();
+    entries -= planet_count;
+    for (size_t i = 0; i < planet_count; ++i)
+    {
+        const ft_planet_build_state &source = entries[i].value;
+        this->_planets.insert(entries[i].key, ft_planet_build_state());
+        Pair<int, ft_planet_build_state> *destination = this->_planets.find(entries[i].key);
+        if (destination == ft_nullptr)
+            continue;
+        ft_planet_build_state &state = destination->value;
+        state.planet_id = source.planet_id;
+        state.width = source.width;
+        state.height = source.height;
+        state.base_logistic = source.base_logistic;
+        state.research_logistic_bonus = source.research_logistic_bonus;
+        state.used_plots = source.used_plots;
+        state.logistic_capacity = source.logistic_capacity;
+        state.logistic_usage = source.logistic_usage;
+        state.base_energy_generation = source.base_energy_generation;
+        state.energy_generation = source.energy_generation;
+        state.energy_consumption = source.energy_consumption;
+        state.support_energy = source.support_energy;
+        state.mine_multiplier = source.mine_multiplier;
+        state.convoy_speed_bonus = source.convoy_speed_bonus;
+        state.convoy_raid_risk_modifier = source.convoy_raid_risk_modifier;
+        state.energy_deficit_pressure = source.energy_deficit_pressure;
+        state.next_instance_id = source.next_instance_id;
+        state.grid.clear();
+        size_t grid_size = source.grid.size();
+        if (grid_size > 0)
+        {
+            state.grid.reserve(grid_size);
+            for (size_t j = 0; j < grid_size; ++j)
+                state.grid.push_back(source.grid[j]);
+        }
+        state.instances.clear();
+        size_t instance_count = source.instances.size();
+        if (instance_count > 0)
+        {
+            const Pair<int, ft_building_instance> *inst_entries = source.instances.end();
+            inst_entries -= instance_count;
+            for (size_t j = 0; j < instance_count; ++j)
+                state.instances.insert(inst_entries[j].key, inst_entries[j].value);
+        }
+    }
+}
+
 void BuildingManager::register_definition(const ft_sharedptr<ft_building_definition> &definition)
 {
     this->_definitions.insert(definition->id, definition);

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -134,6 +134,8 @@ private:
 public:
     BuildingManager();
 
+    void clone_from(const BuildingManager &other);
+
     void initialize_planet(Game &game, int planet_id);
     void add_planet_logistic_bonus(int planet_id, int amount);
     void apply_research_unlock(int research_id);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -920,6 +920,7 @@ bool Game::load_campaign_from_save(const ft_string &planet_json, const ft_string
     bool research_snapshot_present = false;
     ft_map<int, ft_achievement_progress> achievement_state;
     bool achievement_snapshot_present = false;
+    BuildingManager building_snapshot;
     if (planet_json.size() > 0)
         planets_ok = this->_save_system.deserialize_planets(planet_json.c_str(), planet_snapshot);
     if (fleet_json.size() > 0)
@@ -946,7 +947,7 @@ bool Game::load_campaign_from_save(const ft_string &planet_json, const ft_string
         }
     }
     if (building_json.size() > 0)
-        buildings_ok = this->_save_system.deserialize_buildings(building_json.c_str(), this->_buildings);
+        buildings_ok = this->_save_system.deserialize_buildings(building_json.c_str(), building_snapshot);
     else
         buildings_ok = false;
     if (!planets_ok || !fleets_ok || !research_ok || !achievements_ok || !buildings_ok)
@@ -959,6 +960,7 @@ bool Game::load_campaign_from_save(const ft_string &planet_json, const ft_string
     }
     if (achievement_snapshot_present)
         this->_achievements.set_progress_state(achievement_state);
+    this->_buildings.clone_from(building_snapshot);
     this->apply_planet_snapshot(planet_snapshot);
     this->apply_fleet_snapshot(fleet_snapshot);
     return true;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -138,6 +138,8 @@ int main()
         return 0;
     if (!verify_campaign_rejects_invalid_save())
         return 0;
+    if (!verify_buildings_unchanged_on_failed_load())
+        return 0;
 
     server_thread.join();
     return 0;

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -55,5 +55,6 @@ int verify_research_save_round_trip();
 int verify_achievement_save_round_trip();
 int verify_campaign_checkpoint_flow();
 int verify_campaign_rejects_invalid_save();
+int verify_buildings_unchanged_on_failed_load();
 
 #endif


### PR DESCRIPTION
## Summary
- add a clone helper to `BuildingManager` so parsed save data can be copied into the live manager without mutating building definitions
- deserialize buildings into a temporary snapshot inside `Game::load_campaign_from_save` and only apply them after all sections succeed
- add a regression test that ensures valid building data is ignored when other payload sections cause the load to fail

## Testing
- `make test`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_68cefbbbe22c833185019e97c2a742a0