### PR TITLE
Handle empty building payloads in campaign load

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -921,6 +921,7 @@ bool Game::load_campaign_from_save(const ft_string &planet_json, const ft_string
     ft_map<int, ft_achievement_progress> achievement_state;
     bool achievement_snapshot_present = false;
     BuildingManager building_snapshot;
+    bool building_snapshot_present = false;
     if (planet_json.size() > 0)
         planets_ok = this->_save_system.deserialize_planets(planet_json.c_str(), planet_snapshot);
     if (fleet_json.size() > 0)
@@ -947,9 +948,11 @@ bool Game::load_campaign_from_save(const ft_string &planet_json, const ft_string
         }
     }
     if (building_json.size() > 0)
+    {
         buildings_ok = this->_save_system.deserialize_buildings(building_json.c_str(), building_snapshot);
-    else
-        buildings_ok = false;
+        if (buildings_ok)
+            building_snapshot_present = true;
+    }
     if (!planets_ok || !fleets_ok || !research_ok || !achievements_ok || !buildings_ok)
         return false;
     if (research_snapshot_present)
@@ -960,7 +963,8 @@ bool Game::load_campaign_from_save(const ft_string &planet_json, const ft_string
     }
     if (achievement_snapshot_present)
         this->_achievements.set_progress_state(achievement_state);
-    this->_buildings.clone_from(building_snapshot);
+    if (building_snapshot_present)
+        this->_buildings.clone_from(building_snapshot);
     this->apply_planet_snapshot(planet_snapshot);
     this->apply_fleet_snapshot(fleet_snapshot);
     return true;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -130,6 +130,8 @@ int main()
         return 0;
     if (!verify_building_save_round_trip())
         return 0;
+    if (!verify_campaign_load_accepts_empty_building_payload())
+        return 0;
     if (!verify_research_save_round_trip())
         return 0;
     if (!verify_achievement_save_round_trip())

--- a/tests/game_test_save.cpp
+++ b/tests/game_test_save.cpp
@@ -1559,6 +1559,55 @@ int verify_building_save_round_trip()
     return 1;
 }
 
+int verify_campaign_load_accepts_empty_building_payload()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    game.set_ore(PLANET_TERRA, ORE_IRON, 140);
+    game.set_ore(PLANET_TERRA, ORE_COPPER, 120);
+    game.set_ore(PLANET_TERRA, ORE_COAL, 100);
+
+    int generator_uid = game.place_building(PLANET_TERRA, BUILDING_POWER_GENERATOR, 2, 0);
+    FT_ASSERT(generator_uid != 0);
+    int smelter_uid = game.place_building(PLANET_TERRA, BUILDING_SMELTER, 0, 1);
+    FT_ASSERT(smelter_uid != 0);
+
+    game.tick(1.5);
+
+    int baseline_iron = game.get_ore(PLANET_TERRA, ORE_IRON);
+    int baseline_logistics = game.get_planet_logistic_usage(PLANET_TERRA);
+    double baseline_generation = game.get_planet_energy_generation(PLANET_TERRA);
+    double baseline_consumption = game.get_planet_energy_consumption(PLANET_TERRA);
+    FT_ASSERT(baseline_logistics > 0);
+    FT_ASSERT(baseline_generation > 0.0);
+    FT_ASSERT(baseline_consumption > 0.0);
+
+    FT_ASSERT(game.save_campaign_checkpoint(ft_string("empty_building_payload")));
+    ft_string planet_json = game.get_campaign_planet_checkpoint();
+    ft_string fleet_json = game.get_campaign_fleet_checkpoint();
+    ft_string research_json = game.get_campaign_research_checkpoint();
+    ft_string achievement_json = game.get_campaign_achievement_checkpoint();
+    ft_string building_json = game.get_campaign_building_checkpoint();
+    FT_ASSERT(building_json.size() > 0);
+
+    game.set_ore(PLANET_TERRA, ORE_IRON, 0);
+    FT_ASSERT_EQ(0, game.get_ore(PLANET_TERRA, ORE_IRON));
+
+    ft_string empty_building_payload;
+    FT_ASSERT(game.load_campaign_from_save(planet_json, fleet_json, research_json,
+        achievement_json, empty_building_payload));
+
+    FT_ASSERT_EQ(baseline_iron, game.get_ore(PLANET_TERRA, ORE_IRON));
+    FT_ASSERT_EQ(baseline_logistics, game.get_planet_logistic_usage(PLANET_TERRA));
+    double restored_generation = game.get_planet_energy_generation(PLANET_TERRA);
+    double restored_consumption = game.get_planet_energy_consumption(PLANET_TERRA);
+    FT_ASSERT(ft_absolute(restored_generation - baseline_generation) < 0.000001);
+    FT_ASSERT(ft_absolute(restored_consumption - baseline_consumption) < 0.000001);
+    FT_ASSERT_EQ(generator_uid, game.get_building_instance(PLANET_TERRA, 2, 0));
+    FT_ASSERT_EQ(smelter_uid, game.get_building_instance(PLANET_TERRA, 0, 1));
+
+    return 1;
+}
+
 int verify_research_save_round_trip()
 {
     SaveSystem saves;

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -51,6 +51,7 @@ int verify_save_system_massive_payload();
 int verify_save_system_sparse_entries();
 int verify_planet_inventory_save_round_trip();
 int verify_building_save_round_trip();
+int verify_campaign_load_accepts_empty_building_payload();
 int verify_research_save_round_trip();
 int verify_achievement_save_round_trip();
 int verify_campaign_checkpoint_flow();


### PR DESCRIPTION
## Summary
- prevent campaign loads from overwriting building state when the save payload omits building data while still applying other snapshots
- add a regression test that exercises loading with an empty building payload and ensure the harness invokes it

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cefe45618c8331b5fa562dfdf9f9b9