### PR TITLE
Prevent ship ID wraparound near FT_INT_MAX

### DIFF
--- a/src/fleets.cpp
+++ b/src/fleets.cpp
@@ -377,6 +377,8 @@ bool ft_fleet::decay_escort_veterancy(double amount) noexcept
 
 int ft_fleet::create_ship(int ship_type) noexcept
 {
+    if (_next_ship_id >= FT_INT_MAX)
+        return 0;
     int uid = _next_ship_id++;
     ft_ship ship(uid, ship_type);
     assign_ship_defaults(ship);
@@ -394,12 +396,12 @@ void ft_fleet::add_ship_snapshot(const ft_ship &ship) noexcept
     this->_ships.insert(ship.id, ship);
     if (ship.id >= _next_ship_id)
     {
-        if (ship.id >= FT_INT_MAX)
+        if (ship.id >= FT_INT_MAX - 1)
             _next_ship_id = FT_INT_MAX;
         else
         {
             int next_id = ship.id + 1;
-            if (next_id <= ship.id)
+            if (next_id <= ship.id || next_id >= FT_INT_MAX)
                 _next_ship_id = FT_INT_MAX;
             else
                 _next_ship_id = next_id;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -142,6 +142,8 @@ int main()
         return 0;
     if (!verify_buildings_unchanged_on_failed_load())
         return 0;
+    if (!verify_save_system_prevents_ship_id_wraparound())
+        return 0;
 
     server_thread.join();
     return 0;

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -43,6 +43,7 @@ int verify_save_system_invalid_inputs();
 int verify_save_system_rejects_oversized_building_grids();
 int verify_save_system_rejects_overlarge_ship_ids();
 int verify_save_system_limits_inflated_ship_counts();
+int verify_save_system_prevents_ship_id_wraparound();
 int validate_save_system_serialized_samples();
 int verify_save_system_allocation_failures();
 int verify_save_system_extreme_scaling();


### PR DESCRIPTION
## Summary
- guard ft_fleet ship creation against exceeding FT_INT_MAX and clamp snapshot imports near the limit
- add a regression that loads a fleet at the ship ID ceiling and verifies create_ship fails instead of wrapping

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cf0291f79c8331b8373ee0e739f745