### PR TITLE
Prevent building instance ID overflow

### DIFF
--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -420,6 +420,8 @@ int BuildingManager::place_building(Game &game, int planet_id, int building_id, 
         return 0;
     if (!this->is_building_unlocked(building_id))
         return 0;
+    if (state->next_instance_id >= FT_BUILDING_INSTANCE_ID_MAX)
+        return 0;
     if (definition->unique && this->get_building_count(planet_id, building_id) > 0)
         return 0;
     if (definition->occupies_grid && !this->is_area_free(*state, x, y, definition->width, definition->height))

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -7,6 +7,9 @@
 #include "../libft/Template/pair.hpp"
 #include "../libft/Template/shared_ptr.hpp"
 #include "../libft/CPP_class/class_string_class.hpp"
+#include "../libft/Libft/limits.hpp"
+
+static const int FT_BUILDING_INSTANCE_ID_MAX = FT_INT_MAX - 1;
 
 class Game;
 class SaveSystem;

--- a/src/save_system.cpp
+++ b/src/save_system.cpp
@@ -1190,7 +1190,11 @@ bool SaveSystem::deserialize_buildings(const char *content, BuildingManager &bui
                 else if (ft_strcmp(item->key, "energy_deficit_pressure") == 0)
                     state.energy_deficit_pressure = this->unscale_long_to_double(ft_atol(item->value));
                 else if (ft_strcmp(item->key, "next_instance_id") == 0)
+                {
                     state.next_instance_id = ft_atoi(item->value);
+                    if (state.next_instance_id >= FT_BUILDING_INSTANCE_ID_MAX)
+                        state.next_instance_id = FT_BUILDING_INSTANCE_ID_MAX;
+                }
                 else if (ft_strncmp(item->key, "cell_", 5) == 0)
                 {
                     Pair<int, int> entry;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -110,6 +110,8 @@ int main()
         return 0;
     if (!verify_save_system_rejects_oversized_building_grids())
         return 0;
+    if (!verify_save_system_prevents_building_instance_wraparound())
+        return 0;
     if (!verify_save_system_rejects_overlarge_ship_ids())
         return 0;
     if (!verify_save_system_limits_inflated_ship_counts())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -41,6 +41,7 @@ int verify_save_system_round_trip();
 int verify_save_system_edge_cases();
 int verify_save_system_invalid_inputs();
 int verify_save_system_rejects_oversized_building_grids();
+int verify_save_system_prevents_building_instance_wraparound();
 int verify_save_system_rejects_overlarge_ship_ids();
 int verify_save_system_limits_inflated_ship_counts();
 int verify_save_system_prevents_ship_id_wraparound();


### PR DESCRIPTION
## Summary
- clamp deserialized building instance IDs to `FT_BUILDING_INSTANCE_ID_MAX` and block placement when the counter is saturated
- expose the building instance ID limit constant through `buildings.hpp`
- extend the save-system tests to cover saturated instance IDs

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cf05ec70208331824d05218fe88f02