### PR TITLE
Clear unsaved planet items when restoring checkpoints

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,6 +1,7 @@
 #include "game.hpp"
 #include "../libft/Libft/libft.hpp"
 #include "../libft/Template/pair.hpp"
+#include "../libft/Template/set.hpp"
 
 Game::Game(const ft_string &host, const ft_string &path, int difficulty)
     : _backend(host, path),
@@ -742,6 +743,18 @@ void Game::apply_planet_snapshot(const ft_map<int, ft_sharedptr<ft_planet> > &sn
         for (size_t j = 0; j < saved_carryover.size(); ++j)
             planet->set_carryover(saved_carryover[j].key, saved_carryover[j].value);
         ft_vector<Pair<int, int> > inventory_snapshot = saved_planet->get_items_snapshot();
+        ft_set<int> saved_item_ids(inventory_snapshot.size());
+        for (size_t j = 0; j < inventory_snapshot.size(); ++j)
+            saved_item_ids.insert(inventory_snapshot[j].key);
+        ft_vector<Pair<int, int> > current_inventory = planet->get_items_snapshot();
+        for (size_t j = 0; j < current_inventory.size(); ++j)
+        {
+            int existing_item_id = current_inventory[j].key;
+            if (saved_item_ids.find(existing_item_id) != ft_nullptr)
+                continue;
+            planet->set_resource(existing_item_id, 0);
+            this->send_state(planet_id, existing_item_id);
+        }
         for (size_t j = 0; j < inventory_snapshot.size(); ++j)
         {
             int item_id = inventory_snapshot[j].key;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -130,6 +130,8 @@ int main()
         return 0;
     if (!verify_planet_inventory_save_round_trip())
         return 0;
+    if (!verify_planet_inventory_resets_unsaved_items())
+        return 0;
     if (!verify_building_save_round_trip())
         return 0;
     if (!verify_campaign_load_accepts_empty_building_payload())

--- a/tests/game_test_save.cpp
+++ b/tests/game_test_save.cpp
@@ -1577,6 +1577,31 @@ int verify_planet_inventory_save_round_trip()
     return 1;
 }
 
+int verify_planet_inventory_resets_unsaved_items()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+
+    game.set_ore(PLANET_TERRA, ORE_IRON, 88);
+
+    FT_ASSERT(game.save_campaign_checkpoint(ft_string("inventory_cleanup")));
+    ft_string planet_json = game.get_campaign_planet_checkpoint();
+    ft_string fleet_json = game.get_campaign_fleet_checkpoint();
+    ft_string research_json = game.get_campaign_research_checkpoint();
+    ft_string achievement_json = game.get_campaign_achievement_checkpoint();
+    ft_string building_json = game.get_campaign_building_checkpoint();
+
+    game.set_ore(PLANET_TERRA, ITEM_FUSION_REACTOR, 5);
+    FT_ASSERT_EQ(5, game.get_ore(PLANET_TERRA, ITEM_FUSION_REACTOR));
+
+    FT_ASSERT(game.load_campaign_from_save(planet_json, fleet_json, research_json,
+        achievement_json, building_json));
+
+    FT_ASSERT_EQ(88, game.get_ore(PLANET_TERRA, ORE_IRON));
+    FT_ASSERT_EQ(0, game.get_ore(PLANET_TERRA, ITEM_FUSION_REACTOR));
+
+    return 1;
+}
+
 int verify_building_save_round_trip()
 {
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -52,6 +52,7 @@ int verify_save_system_normalizes_non_finite_planet_values();
 int verify_save_system_massive_payload();
 int verify_save_system_sparse_entries();
 int verify_planet_inventory_save_round_trip();
+int verify_planet_inventory_resets_unsaved_items();
 int verify_building_save_round_trip();
 int verify_campaign_load_accepts_empty_building_payload();
 int verify_research_save_round_trip();


### PR DESCRIPTION
## Summary
- clear out any planet inventory entries that are not present in the saved snapshot before replaying checkpoint data
- register the saved item ids in `Game::apply_planet_snapshot` so that the live inventory can be reset to match the checkpoint
- add a regression test that confirms items added after creating a checkpoint disappear once that checkpoint is reloaded

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cf1167116c833184409236183816d2