### PR TITLE
Fix convoy escort assignment persistence

### DIFF
--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -53,6 +53,9 @@ int main()
     if (!verify_convoy_escort_travel_speed())
         return 0;
 
+    if (!verify_convoy_escort_assignment_persistence())
+        return 0;
+
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
     if (!validate_initial_campaign_flow(game))
         return 0;

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -34,6 +34,7 @@ int verify_set_ore_creates_missing_resource();
 int verify_supply_route_key_collisions();
 int verify_trade_relay_convoy_modifiers();
 int verify_convoy_escort_travel_speed();
+int verify_convoy_escort_assignment_persistence();
 int verify_achievement_catalog();
 int verify_achievement_progression();
 int verify_quest_achievement_failures();


### PR DESCRIPTION
## Summary
- ensure dispatch_convoy restores a claimed escort ID when validation fails so the assignment persists
- add a regression test that covers convoys attempting to use a temporarily invalid escort and later succeeding
- wire the new test into the backend test suite listings

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cf137f2ce48331beaa5e46d9ea6d8b