### PR TITLE
Handle underreported ships in fleet deserialization

### DIFF
--- a/src/save_system.cpp
+++ b/src/save_system.cpp
@@ -616,8 +616,14 @@ bool SaveSystem::deserialize_fleets(const char *content,
             ship_count = SAVE_MAX_SHIPS_PER_FLEET;
         if (highest_ship_slot < 0)
             ship_count = 0;
-        else if (ship_count > highest_ship_slot + 1)
-            ship_count = highest_ship_slot + 1;
+        else
+        {
+            int minimum_ship_count = highest_ship_slot + 1;
+            if (minimum_ship_count > SAVE_MAX_SHIPS_PER_FLEET)
+                minimum_ship_count = SAVE_MAX_SHIPS_PER_FLEET;
+            if (ship_count < minimum_ship_count)
+                ship_count = minimum_ship_count;
+        }
         int missing_streak = 0;
         bool saw_ship = false;
         for (int i = 0; i < ship_count; ++i)

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -119,6 +119,8 @@ int main()
         return 0;
     if (!verify_save_system_limits_inflated_ship_counts())
         return 0;
+    if (!verify_save_system_recovers_underreported_ship_counts())
+        return 0;
     if (!validate_save_system_serialized_samples())
         return 0;
     if (!verify_save_system_allocation_failures())

--- a/tests/game_test_save.cpp
+++ b/tests/game_test_save.cpp
@@ -601,6 +601,65 @@ int verify_save_system_limits_inflated_ship_counts()
     return 1;
 }
 
+int verify_save_system_recovers_underreported_ship_counts()
+{
+    SaveSystem saves;
+
+    json_document fleet_doc;
+    json_group *fleet_group = fleet_doc.create_group("fleet_underreported");
+    FT_ASSERT(fleet_group != ft_nullptr);
+    fleet_doc.append_group(fleet_group);
+
+    json_item *fleet_id_item = fleet_doc.create_item("id", 812);
+    FT_ASSERT(fleet_id_item != ft_nullptr);
+    fleet_doc.add_item(fleet_group, fleet_id_item);
+    json_item *ship_count_item = fleet_doc.create_item("ship_count", 1);
+    FT_ASSERT(ship_count_item != ft_nullptr);
+    fleet_doc.add_item(fleet_group, ship_count_item);
+
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_0_id", 4100));
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_0_type", SHIP_CAPITAL));
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_0_hp", 300));
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_1_id", 4200));
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_1_type", SHIP_SHIELD));
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_1_role", SHIP_ROLE_SUPPORT));
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_2_id", 4300));
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_2_type", SHIP_TRANSPORT));
+    fleet_doc.add_item(fleet_group, fleet_doc.create_item("ship_2_hp", 75));
+
+    char *fleet_raw = fleet_doc.write_to_string();
+    FT_ASSERT(fleet_raw != ft_nullptr);
+    ft_string fleet_json(fleet_raw);
+    cma_free(fleet_raw);
+
+    ft_map<int, ft_sharedptr<ft_fleet> > fleets;
+    FT_ASSERT(saves.deserialize_fleets(fleet_json.c_str(), fleets));
+    FT_ASSERT_EQ(1u, fleets.size());
+
+    Pair<int, ft_sharedptr<ft_fleet> > *fleet_entry = fleets.find(812);
+    FT_ASSERT(fleet_entry != ft_nullptr);
+    ft_sharedptr<ft_fleet> restored_fleet = fleet_entry->value;
+    FT_ASSERT(restored_fleet);
+    FT_ASSERT_EQ(3, restored_fleet->get_ship_count());
+
+    const ft_ship *ship_zero = restored_fleet->get_ship(4100);
+    FT_ASSERT(ship_zero != ft_nullptr);
+    FT_ASSERT_EQ(SHIP_CAPITAL, ship_zero->type);
+    FT_ASSERT_EQ(300, ship_zero->hp);
+
+    const ft_ship *ship_one = restored_fleet->get_ship(4200);
+    FT_ASSERT(ship_one != ft_nullptr);
+    FT_ASSERT_EQ(SHIP_SHIELD, ship_one->type);
+    FT_ASSERT_EQ(SHIP_ROLE_SUPPORT, ship_one->role);
+
+    const ft_ship *ship_two = restored_fleet->get_ship(4300);
+    FT_ASSERT(ship_two != ft_nullptr);
+    FT_ASSERT_EQ(SHIP_TRANSPORT, ship_two->type);
+    FT_ASSERT_EQ(75, ship_two->hp);
+
+    return 1;
+}
+
 int verify_save_system_prevents_ship_id_wraparound()
 {
     SaveSystem saves;

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -45,6 +45,7 @@ int verify_save_system_rejects_oversized_building_grids();
 int verify_save_system_prevents_building_instance_wraparound();
 int verify_save_system_rejects_overlarge_ship_ids();
 int verify_save_system_limits_inflated_ship_counts();
+int verify_save_system_recovers_underreported_ship_counts();
 int verify_save_system_prevents_ship_id_wraparound();
 int validate_save_system_serialized_samples();
 int verify_save_system_allocation_failures();


### PR DESCRIPTION
## Summary
- ensure fleet deserialization raises ship_count to cover the highest ship slot discovered
- add a regression test that verifies ships are restored even when ship_count is underreported
- register the new regression in the save-system test harness

## Testing
- `make test`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_68cf17a073288331a557ae42725ef419