### PR TITLE
Sanitize fleet movement stats during deserialization

### DIFF
--- a/src/save_system.cpp
+++ b/src/save_system.cpp
@@ -685,17 +685,35 @@ bool SaveSystem::deserialize_fleets(const char *content,
             key.append("_max_speed");
             json_item *max_speed_item = json_find_item(current, key.c_str());
             if (max_speed_item)
+            {
                 ship_snapshot.max_speed = this->unscale_long_to_double(ft_atol(max_speed_item->value));
+                if (!save_system_is_finite(ship_snapshot.max_speed))
+                    ship_snapshot.max_speed = 0.0;
+                else if (ship_snapshot.max_speed < 0.0)
+                    ship_snapshot.max_speed = 0.0;
+            }
             key = base_key;
             key.append("_acceleration");
             json_item *acceleration_item = json_find_item(current, key.c_str());
             if (acceleration_item)
+            {
                 ship_snapshot.acceleration = this->unscale_long_to_double(ft_atol(acceleration_item->value));
+                if (!save_system_is_finite(ship_snapshot.acceleration))
+                    ship_snapshot.acceleration = 0.0;
+                else if (ship_snapshot.acceleration < 0.0)
+                    ship_snapshot.acceleration = 0.0;
+            }
             key = base_key;
             key.append("_turn_speed");
             json_item *turn_speed_item = json_find_item(current, key.c_str());
             if (turn_speed_item)
+            {
                 ship_snapshot.turn_speed = this->unscale_long_to_double(ft_atol(turn_speed_item->value));
+                if (!save_system_is_finite(ship_snapshot.turn_speed))
+                    ship_snapshot.turn_speed = 0.0;
+                else if (ship_snapshot.turn_speed < 0.0)
+                    ship_snapshot.turn_speed = 0.0;
+            }
             key = base_key;
             key.append("_behavior");
             json_item *behavior_item = json_find_item(current, key.c_str());
@@ -721,6 +739,12 @@ bool SaveSystem::deserialize_fleets(const char *content,
             json_item *role_item = json_find_item(current, key.c_str());
             if (role_item)
                 ship_snapshot.role = ft_atoi(role_item->value);
+            if (!save_system_is_finite(ship_snapshot.max_speed) || ship_snapshot.max_speed < 0.0)
+                ship_snapshot.max_speed = 0.0;
+            if (!save_system_is_finite(ship_snapshot.acceleration) || ship_snapshot.acceleration < 0.0)
+                ship_snapshot.acceleration = 0.0;
+            if (!save_system_is_finite(ship_snapshot.turn_speed) || ship_snapshot.turn_speed < 0.0)
+                ship_snapshot.turn_speed = 0.0;
             fleet->add_ship_snapshot(ship_snapshot);
         }
         fleets.insert(fleet_id, fleet);

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -109,6 +109,8 @@ int main()
         return 0;
     if (!verify_save_system_edge_cases())
         return 0;
+    if (!verify_save_system_sanitizes_ship_movement_stats())
+        return 0;
     if (!verify_save_system_invalid_inputs())
         return 0;
     if (!verify_save_system_rejects_oversized_building_grids())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -40,6 +40,7 @@ int verify_achievement_progression();
 int verify_quest_achievement_failures();
 int verify_save_system_round_trip();
 int verify_save_system_edge_cases();
+int verify_save_system_sanitizes_ship_movement_stats();
 int verify_save_system_invalid_inputs();
 int verify_save_system_rejects_oversized_building_grids();
 int verify_save_system_prevents_building_instance_wraparound();


### PR DESCRIPTION
## Summary
- clamp non-finite or negative ship movement attributes when loading fleets so downstream combat clamps apply safely
- add regression coverage that loads NaN/∞ movement stats and checks the combat tracker remains finite

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68cf97b839108331a9919eba4df3ed34