### PR TITLE
Handle duplicate ship IDs during fleet load

### DIFF
--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -155,6 +155,8 @@ int main()
         return 0;
     if (!verify_save_system_prevents_ship_id_wraparound())
         return 0;
+    if (!verify_save_system_resolves_duplicate_ship_ids())
+        return 0;
 
     server_thread.join();
     return 0;

--- a/tests/game_test_save.cpp
+++ b/tests/game_test_save.cpp
@@ -11,6 +11,7 @@
 
 #define private public
 #define protected public
+#include "game.hpp"
 #include "combat.hpp"
 #undef private
 #undef protected
@@ -801,6 +802,127 @@ int verify_save_system_prevents_ship_id_wraparound()
 
     int wrapped_id = restored_fleet->create_ship(SHIP_SHIELD);
     FT_ASSERT_EQ(0, wrapped_id);
+
+    return 1;
+}
+
+int verify_save_system_resolves_duplicate_ship_ids()
+{
+    SaveSystem saves;
+
+    json_document fleet_doc;
+    json_group *fleet_one = fleet_doc.create_group("fleet_duplicate_one");
+    FT_ASSERT(fleet_one != ft_nullptr);
+    fleet_doc.append_group(fleet_one);
+    json_item *fleet_one_id = fleet_doc.create_item("id", 6100);
+    FT_ASSERT(fleet_one_id != ft_nullptr);
+    fleet_doc.add_item(fleet_one, fleet_one_id);
+    json_item *fleet_one_ship_count = fleet_doc.create_item("ship_count", 3);
+    FT_ASSERT(fleet_one_ship_count != ft_nullptr);
+    fleet_doc.add_item(fleet_one, fleet_one_ship_count);
+    json_item *fleet_one_ship_zero = fleet_doc.create_item("ship_0_id", 1200);
+    FT_ASSERT(fleet_one_ship_zero != ft_nullptr);
+    fleet_doc.add_item(fleet_one, fleet_one_ship_zero);
+    json_item *fleet_one_ship_zero_type = fleet_doc.create_item("ship_0_type", SHIP_SHIELD);
+    FT_ASSERT(fleet_one_ship_zero_type != ft_nullptr);
+    fleet_doc.add_item(fleet_one, fleet_one_ship_zero_type);
+    json_item *fleet_one_ship_one = fleet_doc.create_item("ship_1_id", 1300);
+    FT_ASSERT(fleet_one_ship_one != ft_nullptr);
+    fleet_doc.add_item(fleet_one, fleet_one_ship_one);
+    json_item *fleet_one_ship_one_type = fleet_doc.create_item("ship_1_type", SHIP_RADAR);
+    FT_ASSERT(fleet_one_ship_one_type != ft_nullptr);
+    fleet_doc.add_item(fleet_one, fleet_one_ship_one_type);
+    json_item *fleet_one_ship_two = fleet_doc.create_item("ship_2_id", 1200);
+    FT_ASSERT(fleet_one_ship_two != ft_nullptr);
+    fleet_doc.add_item(fleet_one, fleet_one_ship_two);
+    json_item *fleet_one_ship_two_type = fleet_doc.create_item("ship_2_type", SHIP_CORVETTE);
+    FT_ASSERT(fleet_one_ship_two_type != ft_nullptr);
+    fleet_doc.add_item(fleet_one, fleet_one_ship_two_type);
+
+    json_group *fleet_two = fleet_doc.create_group("fleet_duplicate_two");
+    FT_ASSERT(fleet_two != ft_nullptr);
+    fleet_doc.append_group(fleet_two);
+    json_item *fleet_two_id = fleet_doc.create_item("id", 6101);
+    FT_ASSERT(fleet_two_id != ft_nullptr);
+    fleet_doc.add_item(fleet_two, fleet_two_id);
+    json_item *fleet_two_ship_count = fleet_doc.create_item("ship_count", 2);
+    FT_ASSERT(fleet_two_ship_count != ft_nullptr);
+    fleet_doc.add_item(fleet_two, fleet_two_ship_count);
+    json_item *fleet_two_ship_zero = fleet_doc.create_item("ship_0_id", 1300);
+    FT_ASSERT(fleet_two_ship_zero != ft_nullptr);
+    fleet_doc.add_item(fleet_two, fleet_two_ship_zero);
+    json_item *fleet_two_ship_zero_type = fleet_doc.create_item("ship_0_type", SHIP_SHIELD);
+    FT_ASSERT(fleet_two_ship_zero_type != ft_nullptr);
+    fleet_doc.add_item(fleet_two, fleet_two_ship_zero_type);
+    json_item *fleet_two_ship_one = fleet_doc.create_item("ship_1_id", 1400);
+    FT_ASSERT(fleet_two_ship_one != ft_nullptr);
+    fleet_doc.add_item(fleet_two, fleet_two_ship_one);
+    json_item *fleet_two_ship_one_type = fleet_doc.create_item("ship_1_type", SHIP_TRANSPORT);
+    FT_ASSERT(fleet_two_ship_one_type != ft_nullptr);
+    fleet_doc.add_item(fleet_two, fleet_two_ship_one_type);
+
+    char *raw = fleet_doc.write_to_string();
+    FT_ASSERT(raw != ft_nullptr);
+    ft_string fleet_json(raw);
+    cma_free(raw);
+
+    ft_map<int, ft_sharedptr<ft_fleet> > fleets;
+    FT_ASSERT(saves.deserialize_fleets(fleet_json.c_str(), fleets));
+    FT_ASSERT_EQ(2u, fleets.size());
+
+    Pair<int, ft_sharedptr<ft_fleet> > *fleet_one_entry = fleets.find(6100);
+    FT_ASSERT(fleet_one_entry != ft_nullptr);
+    ft_sharedptr<ft_fleet> restored_one = fleet_one_entry->value;
+    FT_ASSERT(restored_one);
+    FT_ASSERT_EQ(3, restored_one->get_ship_count());
+    const ft_ship *ship_1200 = restored_one->get_ship(1200);
+    FT_ASSERT(ship_1200 != ft_nullptr);
+    FT_ASSERT_EQ(SHIP_SHIELD, ship_1200->type);
+    const ft_ship *ship_1300 = restored_one->get_ship(1300);
+    FT_ASSERT(ship_1300 != ft_nullptr);
+    FT_ASSERT_EQ(SHIP_RADAR, ship_1300->type);
+    const ft_ship *remapped_alpha = restored_one->get_ship(1301);
+    FT_ASSERT(remapped_alpha != ft_nullptr);
+    FT_ASSERT_EQ(SHIP_CORVETTE, remapped_alpha->type);
+
+    Pair<int, ft_sharedptr<ft_fleet> > *fleet_two_entry = fleets.find(6101);
+    FT_ASSERT(fleet_two_entry != ft_nullptr);
+    ft_sharedptr<ft_fleet> restored_two = fleet_two_entry->value;
+    FT_ASSERT(restored_two);
+    FT_ASSERT_EQ(2, restored_two->get_ship_count());
+    FT_ASSERT(restored_two->get_ship(1300) == ft_nullptr);
+    const ft_ship *remapped_beta = restored_two->get_ship(1302);
+    FT_ASSERT(remapped_beta != ft_nullptr);
+    FT_ASSERT_EQ(SHIP_SHIELD, remapped_beta->type);
+    const ft_ship *ship_1400 = restored_two->get_ship(1400);
+    FT_ASSERT(ship_1400 != ft_nullptr);
+    FT_ASSERT_EQ(SHIP_TRANSPORT, ship_1400->type);
+
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    game._escape_pod_protocol = true;
+    game._escape_pod_rescued.insert(1300, false);
+    Pair<int, bool> *escape_before = game._escape_pod_rescued.find(1300);
+    FT_ASSERT(escape_before != ft_nullptr);
+    FT_ASSERT(!escape_before->value);
+
+    FT_ASSERT(game.load_campaign_from_save(ft_string(), fleet_json, ft_string(), ft_string(), ft_string()));
+
+    ft_sharedptr<ft_fleet> loaded_one = game.get_fleet(6100);
+    FT_ASSERT(loaded_one);
+    FT_ASSERT(loaded_one->get_ship(1200) != ft_nullptr);
+    FT_ASSERT(loaded_one->get_ship(1300) != ft_nullptr);
+    FT_ASSERT(loaded_one->get_ship(1301) != ft_nullptr);
+
+    ft_sharedptr<ft_fleet> loaded_two = game.get_fleet(6101);
+    FT_ASSERT(loaded_two);
+    FT_ASSERT(loaded_two->get_ship(1300) == ft_nullptr);
+    FT_ASSERT(loaded_two->get_ship(1302) != ft_nullptr);
+    FT_ASSERT(loaded_two->get_ship(1400) != ft_nullptr);
+
+    Pair<int, bool> *escape_after = game._escape_pod_rescued.find(1300);
+    FT_ASSERT(escape_after != ft_nullptr);
+    FT_ASSERT(!escape_after->value);
+    FT_ASSERT(game._escape_pod_rescued.find(1302) == ft_nullptr);
 
     return 1;
 }

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -48,6 +48,7 @@ int verify_save_system_rejects_overlarge_ship_ids();
 int verify_save_system_limits_inflated_ship_counts();
 int verify_save_system_recovers_underreported_ship_counts();
 int verify_save_system_prevents_ship_id_wraparound();
+int verify_save_system_resolves_duplicate_ship_ids();
 int validate_save_system_serialized_samples();
 int verify_save_system_allocation_failures();
 int verify_save_system_extreme_scaling();


### PR DESCRIPTION
## Summary
- track ship identifiers while loading fleets so duplicates are remapped to fresh IDs
- extend the save-system tests to cover duplicate ID recovery and escape pod bookkeeping
- register the new test with the existing test suite declarations and runner

## Testing
- `make test`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_68cf9aa2ece48331858b99445947d17f