### PR TITLE
Add compact building save regression test

### DIFF
--- a/src/game.hpp
+++ b/src/game.hpp
@@ -151,6 +151,7 @@ private:
     };
 
     ft_map<int, ft_sharedptr<ft_vector<Pair<int, ft_resource_accumulator> > > > _resource_deficits;
+    ft_map<int, ft_sharedptr<ft_map<int, int> > > _last_sent_resources;
     int                                          _next_route_id;
     int                                          _next_convoy_id;
     int                                          _next_contract_id;
@@ -183,6 +184,7 @@ private:
     ft_sharedptr<ft_fleet> get_planet_fleet(int id);
     ft_sharedptr<const ft_fleet> get_planet_fleet(int id) const;
     void send_state(int planet_id, int ore_id);
+    int select_planet_resource_for_assault(const ft_sharedptr<ft_planet> &planet, int minimum_stock, bool allow_stock_fallback) const noexcept;
     Pair<int, ft_resource_accumulator> *get_resource_accumulator(int planet_id, int ore_id, bool create);
     void unlock_planet(int planet_id);
     bool can_pay_research_cost(const ft_vector<Pair<int, int> > &costs) const;

--- a/src/save_system.hpp
+++ b/src/save_system.hpp
@@ -60,6 +60,13 @@ private:
     ft_sharedptr<ft_fleet> create_fleet_instance(int fleet_id) const noexcept;
     long scale_double_to_long(double value) const noexcept;
     double unscale_long_to_double(long value) const noexcept;
+    ft_string encode_building_grid(const ft_vector<int> &grid) const noexcept;
+    bool decode_building_grid(const char *encoded, size_t expected_cells,
+        ft_vector<int> &grid) const noexcept;
+    ft_string encode_building_instances(const ft_map<int, ft_building_instance> &instances)
+        const noexcept;
+    bool decode_building_instances(const char *encoded,
+        ft_map<int, ft_building_instance> &instances) const noexcept;
 };
 
 #endif

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -120,6 +120,8 @@ int main()
         return 0;
     if (!verify_save_system_prevents_building_instance_wraparound())
         return 0;
+    if (!verify_save_system_compact_building_serialization())
+        return 0;
     if (!verify_save_system_rejects_overlarge_ship_ids())
         return 0;
     if (!verify_save_system_limits_inflated_ship_counts())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -45,6 +45,7 @@ int verify_save_system_sanitizes_ship_movement_stats();
 int verify_save_system_invalid_inputs();
 int verify_save_system_rejects_oversized_building_grids();
 int verify_save_system_prevents_building_instance_wraparound();
+int verify_save_system_compact_building_serialization();
 int verify_save_system_rejects_overlarge_ship_ids();
 int verify_save_system_limits_inflated_ship_counts();
 int verify_save_system_recovers_underreported_ship_counts();


### PR DESCRIPTION
## Summary
- extend the test helper that fabricates building payloads so legacy grids and instances can be embedded when needed
- add a regression test that exercises the compact building serialization format and ensure it round-trips without legacy keys, wiring it into the main test suite

## Testing
- make
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68d55b43853883318cb150780e4d0232