### PR TITLE
Refactor research and quest registries to data tables

### DIFF
--- a/src/planets.hpp
+++ b/src/planets.hpp
@@ -6,6 +6,7 @@
 #include "../libft/Template/shared_ptr.hpp"
 #include "../libft/Template/vector.hpp"
 #include "../libft/Template/pair.hpp"
+#include "../libft/Template/map.hpp"
 #include "../libft/CPP_class/class_nullptr.hpp"
 
 enum e_planet_id
@@ -50,9 +51,13 @@ class ft_planet : public ft_character
 {
 protected:
     int                                     _id;
-    ft_vector<Pair<int, ft_sharedptr<ft_item> > > _items;
-    ft_vector<Pair<int, double> >           _rates;
-    ft_vector<Pair<int, double> >           _carryover;
+    ft_map<int, ft_sharedptr<ft_item> >     _items;
+    ft_map<int, double>                     _rates;
+    ft_map<int, double>                     _carryover;
+    mutable ft_vector<Pair<int, double> >   _rates_cache;
+    mutable bool                            _rates_cache_dirty;
+    mutable ft_vector<Pair<int, double> >   _carryover_cache;
+    mutable bool                            _carryover_cache_dirty;
 
     ft_sharedptr<ft_item> find_item(int ore_id) noexcept;
     ft_sharedptr<const ft_item> find_item(int ore_id) const noexcept;


### PR DESCRIPTION
## Summary
- move research definitions into static template tables and hydrate ft_research_definition instances via shared copy helpers
- generate quest definitions from reusable prerequisite/objective/choice arrays to eliminate hand-maintained constructor duplication

## Testing
- make test *(fails: libft target Full_Libft.a missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d58c630b6883319cbce2f45a010702