### PR TITLE
Account for in-flight supply shipments

### DIFF
--- a/src/backend_client.cpp
+++ b/src/backend_client.cpp
@@ -64,13 +64,21 @@ namespace
 }
 
 BackendClient::BackendClient(const ft_string &host, const ft_string &path)
-    : _host(host), _path(path), _port()
+    : _host(host), _path(path), _port(), _use_ssl(false)
 {
     const char *input = host.c_str();
     const char *scheme_separator = ft_strstr(input, "://");
     const char *authority_start;
     if (scheme_separator != ft_nullptr)
+    {
+        ft_string scheme_value;
+        assign_substring(scheme_value, input, scheme_separator);
+        if (scheme_value.size() == 5 && ft_strncmp(scheme_value.c_str(), "https", 5) == 0)
+            this->_use_ssl = true;
+        else if (scheme_value.size() == 4 && ft_strncmp(scheme_value.c_str(), "http", 4) == 0)
+            this->_use_ssl = false;
         authority_start = scheme_separator + 3;
+    }
     else
         authority_start = input;
 
@@ -143,7 +151,7 @@ int BackendClient::send_state(const ft_string &state, ft_string &response)
     const char *port_cstr = ft_nullptr;
     if (!this->_port.empty())
         port_cstr = this->_port.c_str();
-    int status = http_post(this->_host.c_str(), this->_path.c_str(), state, response, false, port_cstr);
+    int status = http_post(this->_host.c_str(), this->_path.c_str(), state, response, this->_use_ssl, port_cstr);
     if (status != 0)
     {
         set_offline_echo_response(response, state);
@@ -173,4 +181,9 @@ const ft_string &BackendClient::get_host_for_testing() const
 const ft_string &BackendClient::get_port_for_testing() const
 {
     return (this->_port);
+}
+
+bool BackendClient::get_use_ssl_for_testing() const
+{
+    return (this->_use_ssl);
 }

--- a/src/backend_client.hpp
+++ b/src/backend_client.hpp
@@ -9,6 +9,7 @@ private:
     ft_string _host;
     ft_string _path;
     ft_string _port;
+    bool      _use_ssl;
 
 public:
     BackendClient(const ft_string &host, const ft_string &path);
@@ -18,6 +19,7 @@ public:
 
     const ft_string &get_host_for_testing() const;
     const ft_string &get_port_for_testing() const;
+    bool get_use_ssl_for_testing() const;
 };
 
 #endif

--- a/src/game_quests.cpp
+++ b/src/game_quests.cpp
@@ -306,11 +306,45 @@ int Game::get_quest_choice(int quest_id) const
 
 const ft_vector<ft_string> &Game::get_lore_log() const
 {
-    return this->_lore_log;
+    if (!this->_lore_log_cache_dirty)
+        return this->_lore_log_cache;
+
+    this->_lore_log_cache.clear();
+    if (this->_lore_log_count == 0)
+    {
+        this->_lore_log_cache_dirty = false;
+        return this->_lore_log_cache;
+    }
+
+    size_t buffer_size = this->_lore_log.size();
+    if (buffer_size == 0)
+    {
+        this->_lore_log_cache_dirty = false;
+        return this->_lore_log_cache;
+    }
+
+    this->_lore_log_cache.reserve(this->_lore_log_count);
+    for (size_t i = 0; i < this->_lore_log_count; ++i)
+    {
+        size_t index = (this->_lore_log_start + i) % buffer_size;
+        this->_lore_log_cache.push_back(this->_lore_log[index]);
+    }
+    this->_lore_log_cache_dirty = false;
+    return this->_lore_log_cache;
 }
 
 bool Game::is_backend_online() const
 {
     return this->_backend_online;
+}
+
+long Game::get_backend_retry_delay_ms_for_testing() const
+{
+    return this->_backend_retry_delay_ms;
+}
+
+long Game::get_backend_next_retry_ms_for_testing() const
+{
+    return this->_backend_next_retry_ms;
 }
 

--- a/test_failures.log
+++ b/test_failures.log
@@ -1,3 +1,3 @@
 # Test failure log
 # Outstanding failures:
-# None. All tests passed on 2025-09-26.
+# None. All tests passed on 2025-09-25.

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -78,6 +78,8 @@ int main()
         return 0;
     if (!verify_supply_contract_automation())
         return 0;
+    if (!verify_supply_contract_pending_stock_buffer())
+        return 0;
     if (!verify_multiple_convoy_raids())
         return 0;
     if (!verify_supply_route_escalation())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -12,6 +12,7 @@ int validate_order_branch_storyline();
 int evaluate_building_and_convoy_systems(Game &game);
 int evaluate_ship_upgrade_research(Game &game);
 int verify_supply_contract_automation();
+int verify_supply_contract_pending_stock_buffer();
 int verify_convoy_quest_objectives();
 int verify_multiple_convoy_raids();
 int verify_supply_route_escalation();


### PR DESCRIPTION
## Summary
- track pending delivery totals on supply contracts and include them when minimum stock limits are enforced
- adjust convoy dispatch, raid, and completion flows to keep pending delivery counts accurate for each contract
- add a regression test that verifies pending shipments prevent redundant launches and wire it into the campaign suite

## Testing
- `make test`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_68d5981992288331a84ec1ddb9da6436