### PR TITLE
Make ft_planet_build_state copyable for snapshots

### DIFF
--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -103,6 +103,10 @@ struct ft_planet_build_state
     ft_map<int, ft_building_instance> instances;
 
     ft_planet_build_state();
+    ft_planet_build_state(const ft_planet_build_state &other);
+    ft_planet_build_state &operator=(const ft_planet_build_state &other);
+    ft_planet_build_state(ft_planet_build_state &&other) noexcept;
+    ft_planet_build_state &operator=(ft_planet_build_state &&other) noexcept;
 };
 
 class BuildingManager

--- a/src/buildings_catalog.cpp
+++ b/src/buildings_catalog.cpp
@@ -2,6 +2,7 @@
 #include "game.hpp"
 #include "research.hpp"
 #include "../libft/Libft/libft.hpp"
+#include "ft_map_snapshot.hpp"
 
 ft_planet_build_state::ft_planet_build_state()
     : planet_id(0), width(0), height(0), base_logistic(0), research_logistic_bonus(0), used_plots(0),
@@ -10,6 +11,134 @@ ft_planet_build_state::ft_planet_build_state()
       mine_multiplier(1.0), convoy_speed_bonus(0.0), convoy_raid_risk_modifier(0.0),
       energy_deficit_pressure(0.0), next_instance_id(1), grid(), instances()
 {
+}
+
+ft_planet_build_state::ft_planet_build_state(const ft_planet_build_state &other)
+    : planet_id(0), width(0), height(0), base_logistic(0), research_logistic_bonus(0), used_plots(0),
+      logistic_capacity(0), logistic_usage(0), base_energy_generation(0.0),
+      energy_generation(0.0), energy_consumption(0.0), support_energy(0.0),
+      mine_multiplier(1.0), convoy_speed_bonus(0.0), convoy_raid_risk_modifier(0.0),
+      energy_deficit_pressure(0.0), next_instance_id(1), grid(), instances()
+{
+    *this = other;
+}
+
+ft_planet_build_state &ft_planet_build_state::operator=(const ft_planet_build_state &other)
+{
+    if (this == &other)
+        return *this;
+    this->planet_id = other.planet_id;
+    this->width = other.width;
+    this->height = other.height;
+    this->base_logistic = other.base_logistic;
+    this->research_logistic_bonus = other.research_logistic_bonus;
+    this->used_plots = other.used_plots;
+    this->logistic_capacity = other.logistic_capacity;
+    this->logistic_usage = other.logistic_usage;
+    this->base_energy_generation = other.base_energy_generation;
+    this->energy_generation = other.energy_generation;
+    this->energy_consumption = other.energy_consumption;
+    this->support_energy = other.support_energy;
+    this->mine_multiplier = other.mine_multiplier;
+    this->convoy_speed_bonus = other.convoy_speed_bonus;
+    this->convoy_raid_risk_modifier = other.convoy_raid_risk_modifier;
+    this->energy_deficit_pressure = other.energy_deficit_pressure;
+    this->next_instance_id = other.next_instance_id;
+
+    this->grid.clear();
+    size_t grid_size = other.grid.size();
+    if (grid_size > 0)
+    {
+        this->grid.reserve(grid_size);
+        for (size_t index = 0; index < grid_size; ++index)
+            this->grid.push_back(other.grid[index]);
+    }
+
+    this->instances.clear();
+    ft_vector<Pair<int, ft_building_instance> > instance_entries;
+    ft_map_snapshot(other.instances, instance_entries);
+    for (size_t index = 0; index < instance_entries.size(); ++index)
+        this->instances.insert(instance_entries[index].key, instance_entries[index].value);
+
+    return *this;
+}
+
+ft_planet_build_state::ft_planet_build_state(ft_planet_build_state &&other) noexcept
+    : planet_id(other.planet_id), width(other.width), height(other.height),
+      base_logistic(other.base_logistic), research_logistic_bonus(other.research_logistic_bonus),
+      used_plots(other.used_plots), logistic_capacity(other.logistic_capacity),
+      logistic_usage(other.logistic_usage), base_energy_generation(other.base_energy_generation),
+      energy_generation(other.energy_generation), energy_consumption(other.energy_consumption),
+      support_energy(other.support_energy), mine_multiplier(other.mine_multiplier),
+      convoy_speed_bonus(other.convoy_speed_bonus),
+      convoy_raid_risk_modifier(other.convoy_raid_risk_modifier),
+      energy_deficit_pressure(other.energy_deficit_pressure), next_instance_id(other.next_instance_id),
+      grid(ft_move(other.grid)), instances(ft_move(other.instances))
+{
+    other.planet_id = 0;
+    other.width = 0;
+    other.height = 0;
+    other.base_logistic = 0;
+    other.research_logistic_bonus = 0;
+    other.used_plots = 0;
+    other.logistic_capacity = 0;
+    other.logistic_usage = 0;
+    other.base_energy_generation = 0.0;
+    other.energy_generation = 0.0;
+    other.energy_consumption = 0.0;
+    other.support_energy = 0.0;
+    other.mine_multiplier = 1.0;
+    other.convoy_speed_bonus = 0.0;
+    other.convoy_raid_risk_modifier = 0.0;
+    other.energy_deficit_pressure = 0.0;
+    other.next_instance_id = 1;
+}
+
+ft_planet_build_state &ft_planet_build_state::operator=(ft_planet_build_state &&other) noexcept
+{
+    if (this == &other)
+        return *this;
+
+    this->planet_id = other.planet_id;
+    this->width = other.width;
+    this->height = other.height;
+    this->base_logistic = other.base_logistic;
+    this->research_logistic_bonus = other.research_logistic_bonus;
+    this->used_plots = other.used_plots;
+    this->logistic_capacity = other.logistic_capacity;
+    this->logistic_usage = other.logistic_usage;
+    this->base_energy_generation = other.base_energy_generation;
+    this->energy_generation = other.energy_generation;
+    this->energy_consumption = other.energy_consumption;
+    this->support_energy = other.support_energy;
+    this->mine_multiplier = other.mine_multiplier;
+    this->convoy_speed_bonus = other.convoy_speed_bonus;
+    this->convoy_raid_risk_modifier = other.convoy_raid_risk_modifier;
+    this->energy_deficit_pressure = other.energy_deficit_pressure;
+    this->next_instance_id = other.next_instance_id;
+
+    this->grid = ft_move(other.grid);
+    this->instances = ft_move(other.instances);
+
+    other.planet_id = 0;
+    other.width = 0;
+    other.height = 0;
+    other.base_logistic = 0;
+    other.research_logistic_bonus = 0;
+    other.used_plots = 0;
+    other.logistic_capacity = 0;
+    other.logistic_usage = 0;
+    other.base_energy_generation = 0.0;
+    other.energy_generation = 0.0;
+    other.energy_consumption = 0.0;
+    other.support_energy = 0.0;
+    other.mine_multiplier = 1.0;
+    other.convoy_speed_bonus = 0.0;
+    other.convoy_raid_risk_modifier = 0.0;
+    other.energy_deficit_pressure = 0.0;
+    other.next_instance_id = 1;
+
+    return *this;
 }
 
 BuildingManager::BuildingManager()

--- a/src/ft_map_snapshot.hpp
+++ b/src/ft_map_snapshot.hpp
@@ -1,0 +1,22 @@
+#ifndef FT_MAP_SNAPSHOT_HPP
+#define FT_MAP_SNAPSHOT_HPP
+
+#include "../libft/Template/map.hpp"
+#include "../libft/Template/vector.hpp"
+#include "../libft/Template/pair.hpp"
+
+template <typename Key, typename Value>
+void ft_map_snapshot(const ft_map<Key, Value> &map, ft_vector<Pair<Key, Value> > &out)
+{
+    size_t count = map.size();
+    out.clear();
+    if (count == 0)
+        return;
+    out.reserve(count);
+    const Pair<Key, Value> *entries = map.end();
+    entries -= count;
+    for (size_t i = 0; i < count; ++i)
+        out.push_back(entries[i]);
+}
+
+#endif

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -156,8 +156,24 @@ private:
         {}
     };
 
+    struct ft_pending_resource_update
+    {
+        int planet_id;
+        int ore_id;
+        int amount;
+
+        ft_pending_resource_update()
+            : planet_id(0), ore_id(0), amount(0)
+        {}
+
+        ft_pending_resource_update(int planet, int ore, int value)
+            : planet_id(planet), ore_id(ore), amount(value)
+        {}
+    };
+
     ft_map<int, ft_sharedptr<ft_vector<Pair<int, ft_resource_accumulator> > > > _resource_deficits;
     ft_map<int, ft_sharedptr<ft_map<int, int> > > _last_sent_resources;
+    ft_map<int, ft_sharedptr<ft_map<int, int> > > _pending_resource_updates;
     int                                          _next_route_id;
     int                                          _next_convoy_id;
     int                                          _next_contract_id;
@@ -196,6 +212,10 @@ private:
     ft_sharedptr<ft_fleet> get_planet_fleet(int id);
     ft_sharedptr<const ft_fleet> get_planet_fleet(int id) const;
     void send_state(int planet_id, int ore_id);
+    void queue_pending_resource_update(int planet_id, int ore_id, int amount);
+    void clear_pending_resource_update(int planet_id, int ore_id);
+    bool flush_pending_resource_updates();
+    bool dispatch_resource_update(int planet_id, int ore_id, int amount);
     int select_planet_resource_for_assault(const ft_sharedptr<ft_planet> &planet, int minimum_stock, bool allow_stock_fallback) const noexcept;
     Pair<int, ft_resource_accumulator> *get_resource_accumulator(int planet_id, int ore_id, bool create);
     void unlock_planet(int planet_id);

--- a/src/game_quests.cpp
+++ b/src/game_quests.cpp
@@ -1,12 +1,13 @@
 #include "game.hpp"
 #include "../libft/Libft/libft.hpp"
 #include "../libft/Template/pair.hpp"
+#include "ft_map_snapshot.hpp"
 
 void Game::build_quest_context(ft_quest_context &context) const
 {
-    size_t planet_count = this->_planets.size();
-    const Pair<int, ft_sharedptr<ft_planet> > *planet_entries = this->_planets.end();
-    planet_entries -= planet_count;
+    ft_vector<Pair<int, ft_sharedptr<ft_planet> > > planet_entries;
+    ft_map_snapshot(this->_planets, planet_entries);
+    size_t planet_count = planet_entries.size();
     for (size_t i = 0; i < planet_count; ++i)
     {
         const ft_sharedptr<ft_planet> &planet = planet_entries[i].value;
@@ -33,19 +34,17 @@ void Game::build_quest_context(ft_quest_context &context) const
     context.research_status.insert(RESEARCH_REPAIR_DRONE_TECHNOLOGY, this->_research.is_completed(RESEARCH_REPAIR_DRONE_TECHNOLOGY) ? 1 : 0);
     context.research_status.insert(RESEARCH_CAPITAL_SHIP_INITIATIVE, this->_research.is_completed(RESEARCH_CAPITAL_SHIP_INITIATIVE) ? 1 : 0);
 
-    size_t fleet_count = this->_fleets.size();
-    const Pair<int, ft_sharedptr<ft_fleet> > *fleet_entries = this->_fleets.end();
-    fleet_entries -= fleet_count;
-    for (size_t i = 0; i < fleet_count; ++i)
+    ft_vector<Pair<int, ft_sharedptr<ft_fleet> > > fleet_entries;
+    ft_map_snapshot(this->_fleets, fleet_entries);
+    for (size_t i = 0; i < fleet_entries.size(); ++i)
     {
         const ft_sharedptr<ft_fleet> &fleet = fleet_entries[i].value;
         context.total_ship_count += fleet->get_ship_count();
         context.total_ship_hp += fleet->get_total_ship_hp();
     }
-    size_t garrison_count = this->_planet_fleets.size();
-    const Pair<int, ft_sharedptr<ft_fleet> > *garrison_entries = this->_planet_fleets.end();
-    garrison_entries -= garrison_count;
-    for (size_t i = 0; i < garrison_count; ++i)
+    ft_vector<Pair<int, ft_sharedptr<ft_fleet> > > garrison_entries;
+    ft_map_snapshot(this->_planet_fleets, garrison_entries);
+    for (size_t i = 0; i < garrison_entries.size(); ++i)
     {
         const ft_sharedptr<ft_fleet> &fleet = garrison_entries[i].value;
         context.total_ship_count += fleet->get_ship_count();
@@ -56,11 +55,11 @@ void Game::build_quest_context(ft_quest_context &context) const
     context.delivery_streak = this->_current_delivery_streak;
     double total_threat = 0.0;
     double max_threat = 0.0;
-    size_t route_count = this->_supply_routes.size();
+    ft_vector<Pair<RouteKey, ft_supply_route> > route_entries;
+    ft_map_snapshot(this->_supply_routes, route_entries);
+    size_t route_count = route_entries.size();
     if (route_count > 0)
     {
-        const Pair<RouteKey, ft_supply_route> *route_entries = this->_supply_routes.end();
-        route_entries -= route_count;
         for (size_t i = 0; i < route_count; ++i)
         {
             double threat = route_entries[i].value.threat_level;

--- a/src/game_research.cpp
+++ b/src/game_research.cpp
@@ -1,6 +1,7 @@
 #include "game.hpp"
 #include "../libft/Libft/libft.hpp"
 #include "../libft/Template/pair.hpp"
+#include "ft_map_snapshot.hpp"
 
 bool Game::can_pay_research_cost(const ft_vector<Pair<int, int> > &costs) const
 {
@@ -9,10 +10,9 @@ bool Game::can_pay_research_cost(const ft_vector<Pair<int, int> > &costs) const
         int ore_id = costs[i].key;
         int required = costs[i].value;
         int total = 0;
-        size_t count = this->_planets.size();
-        const Pair<int, ft_sharedptr<ft_planet> > *entries = this->_planets.end();
-        entries -= count;
-        for (size_t j = 0; j < count; ++j)
+        ft_vector<Pair<int, ft_sharedptr<ft_planet> > > entries;
+        ft_map_snapshot(this->_planets, entries);
+        for (size_t j = 0; j < entries.size(); ++j)
         {
             const ft_sharedptr<ft_planet> &planet = entries[j].value;
             total += planet->get_resource(ore_id);
@@ -33,10 +33,9 @@ void Game::pay_research_cost(const ft_vector<Pair<int, int> > &costs)
         int remaining = costs[i].value;
         if (remaining <= 0)
             continue;
-        size_t count = this->_planets.size();
-        Pair<int, ft_sharedptr<ft_planet> > *entries = this->_planets.end();
-        entries -= count;
-        for (size_t j = 0; j < count && remaining > 0; ++j)
+        ft_vector<Pair<int, ft_sharedptr<ft_planet> > > entries;
+        ft_map_snapshot(this->_planets, entries);
+        for (size_t j = 0; j < entries.size() && remaining > 0; ++j)
         {
             ft_sharedptr<ft_planet> planet = entries[j].value;
             int available = planet->get_resource(ore_id);
@@ -103,13 +102,13 @@ void Game::handle_research_completion(int research_id)
     else if (research_id == RESEARCH_ESCAPE_POD_LIFELINE)
     {
         this->_escape_pod_protocol = true;
-        size_t saved = this->_escape_pod_rescued.size();
-        if (saved > 0)
+        ft_vector<Pair<int, bool> > entries;
+        ft_map_snapshot(this->_escape_pod_rescued, entries);
+        for (size_t i = 0; i < entries.size(); ++i)
         {
-            Pair<int, bool> *entries = this->_escape_pod_rescued.end();
-            entries -= saved;
-            for (size_t i = 0; i < saved; ++i)
-                entries[i].value = false;
+            Pair<int, bool> *entry = this->_escape_pod_rescued.find(entries[i].key);
+            if (entry != ft_nullptr)
+                entry->value = false;
         }
     }
     this->record_achievement_event(ACHIEVEMENT_EVENT_RESEARCH_COMPLETED, 1);


### PR DESCRIPTION
## Summary
- add explicit copy and move special members to `ft_planet_build_state` so snapshot iteration can safely duplicate planet build data
- teach the planet state copier to clone grids and instance maps using the ft_map_snapshot helper and clear snapshot vectors before reuse
- update quest context construction to cache the planet count now that snapshot iteration works with copyable states

## Testing
- make
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68d5a2ce97788331b1ec83aa9e70831a