### PR TITLE
Sanitize backend host input before parsing

### DIFF
--- a/src/backend_client.cpp
+++ b/src/backend_client.cpp
@@ -48,6 +48,22 @@ namespace
         }
     }
 
+    ft_string sanitize_host_input(const ft_string &raw)
+    {
+        const char *begin = raw.c_str();
+        if (begin == ft_nullptr)
+            return ft_string();
+        const char *trim_start = begin;
+        while (*trim_start != '\0' && ft_isspace(*trim_start))
+            trim_start += 1;
+        const char *trim_end = trim_start + ft_strlen(trim_start);
+        while (trim_end > trim_start && ft_isspace(*(trim_end - 1)))
+            trim_end -= 1;
+        ft_string sanitized;
+        assign_substring(sanitized, trim_start, trim_end);
+        return sanitized;
+    }
+
     bool is_numeric_range(const char *begin, const char *end)
     {
         if (begin == end)
@@ -66,7 +82,8 @@ namespace
 BackendClient::BackendClient(const ft_string &host, const ft_string &path)
     : _host(host), _path(path), _port(), _use_ssl(false)
 {
-    const char *input = host.c_str();
+    ft_string sanitized_input = sanitize_host_input(host);
+    const char *input = sanitized_input.c_str();
     const char *scheme_separator = ft_strstr(input, "://");
     const char *authority_start;
     if (scheme_separator != ft_nullptr)

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -239,6 +239,13 @@ int verify_backend_host_parsing()
     FT_ASSERT_EQ(expected_path_port, scheme_with_path.get_port_for_testing());
     FT_ASSERT(scheme_with_path.get_use_ssl_for_testing());
 
+    BackendClient whitespace_client(ft_string("  https://example.net:9090  "), ft_string("/"));
+    ft_string expected_whitespace_host("example.net");
+    FT_ASSERT_EQ(expected_whitespace_host, whitespace_client.get_host_for_testing());
+    ft_string expected_whitespace_port("9090");
+    FT_ASSERT_EQ(expected_whitespace_port, whitespace_client.get_port_for_testing());
+    FT_ASSERT(whitespace_client.get_use_ssl_for_testing());
+
     return 1;
 }
 


### PR DESCRIPTION
## Summary
- trim leading and trailing whitespace from backend host strings before parsing
- add a regression test that covers whitespace-padded backend host inputs

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68d6289f37908331ab895f7bdfbdd486