### PR TITLE
Add player profile management and swap option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ SRC_COMMON  = \
     $(SRC_DIR)/combat_tracks.cpp \
     $(SRC_DIR)/combat_formations.cpp \
     $(SRC_DIR)/combat_tick.cpp \
+    $(SRC_DIR)/game_bootstrap.cpp \
+    $(SRC_DIR)/player_profile.cpp \
     $(SRC_DIR)/quests.cpp \
     $(SRC_DIR)/research.cpp \
     $(SRC_DIR)/game_research.cpp \

--- a/src/game_bootstrap.cpp
+++ b/src/game_bootstrap.cpp
@@ -1,0 +1,206 @@
+#include "game_bootstrap.hpp"
+
+#include "../libft/CMA/CMA.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+#include "../libft/CPP_class/class_ofstream.hpp"
+#include "../libft/JSon/document.hpp"
+#include "../libft/JSon/json.hpp"
+#include "../libft/Libft/limits.hpp"
+#include "../libft/Libft/libft.hpp"
+
+namespace
+{
+    const double kBootstrapRateScale = 1000000.0;
+
+    long bootstrap_scale_double(double value) noexcept
+    {
+        double scaled = value * kBootstrapRateScale;
+        if (scaled >= 0.0)
+            scaled += 0.5;
+        else
+            scaled -= 0.5;
+        if (scaled > static_cast<double>(FT_LONG_MAX))
+            scaled = static_cast<double>(FT_LONG_MAX);
+        if (scaled < static_cast<double>(FT_LONG_MIN))
+            scaled = static_cast<double>(FT_LONG_MIN);
+        return static_cast<long>(scaled);
+    }
+
+    ft_string bootstrap_abort(json_document &document) noexcept
+    {
+        document.clear();
+        return ft_string();
+    }
+
+    bool bootstrap_append_group(json_document &document, json_group *group) noexcept
+    {
+        if (group == ft_nullptr)
+            return false;
+        document.append_group(group);
+        return true;
+    }
+
+    bool bootstrap_add_item(json_document &document, json_group *group, const char *key, int value) noexcept
+    {
+        if (group == ft_nullptr || key == ft_nullptr)
+            return false;
+        json_item *item = document.create_item(key, value);
+        if (!item)
+            return false;
+        document.add_item(group, item);
+        return true;
+    }
+
+    bool bootstrap_add_item(json_document &document, json_group *group, const char *key, const ft_string &value) noexcept
+    {
+        if (group == ft_nullptr || key == ft_nullptr)
+            return false;
+        json_item *item = document.create_item(key, value.c_str());
+        if (!item)
+            return false;
+        document.add_item(group, item);
+        return true;
+    }
+
+    void bootstrap_populate_planet_defaults(GameBootstrapData &out_data) noexcept
+    {
+        ft_planet_terra terra;
+
+        out_data.starting_planet.id = PLANET_TERRA;
+        out_data.starting_planet.resources.clear();
+
+        GameBootstrapPlanetResource iron(ORE_IRON, 200, terra.get_rate(ORE_IRON));
+        GameBootstrapPlanetResource copper(ORE_COPPER, 120, terra.get_rate(ORE_COPPER));
+        GameBootstrapPlanetResource coal(ORE_COAL, 80, terra.get_rate(ORE_COAL));
+
+        out_data.starting_planet.resources.push_back(iron);
+        out_data.starting_planet.resources.push_back(copper);
+        out_data.starting_planet.resources.push_back(coal);
+    }
+
+    void bootstrap_populate_player_inventory(GameBootstrapData &out_data) noexcept
+    {
+        out_data.player_resources.clear();
+
+        GameBootstrapResource iron(ORE_IRON, 60);
+        GameBootstrapResource copper(ORE_COPPER, 40);
+        GameBootstrapResource coal(ORE_COAL, 20);
+
+        out_data.player_resources.push_back(iron);
+        out_data.player_resources.push_back(copper);
+        out_data.player_resources.push_back(coal);
+    }
+}
+
+bool game_bootstrap_initialize_with_commander(GameBootstrapData &out_data, const ft_string &commander_name) noexcept
+{
+    out_data.commander_name = commander_name;
+    if (out_data.commander_name.empty())
+        out_data.commander_name = ft_string("Commander");
+    bootstrap_populate_planet_defaults(out_data);
+    bootstrap_populate_player_inventory(out_data);
+    return true;
+}
+
+bool game_bootstrap_initialize_default(GameBootstrapData &out_data) noexcept
+{
+    const ft_string default_name("Commander");
+    return game_bootstrap_initialize_with_commander(out_data, default_name);
+}
+
+ft_string game_bootstrap_serialize(const GameBootstrapData &data) noexcept
+{
+    json_document document;
+
+    json_group *metadata_group = document.create_group("metadata");
+    if (!bootstrap_append_group(document, metadata_group))
+        return bootstrap_abort(document);
+    if (!bootstrap_add_item(document, metadata_group, "version", 1))
+        return bootstrap_abort(document);
+    const ft_string save_type("quicksave");
+    if (!bootstrap_add_item(document, metadata_group, "save_type", save_type))
+        return bootstrap_abort(document);
+
+    json_group *player_group = document.create_group("player");
+    if (!bootstrap_append_group(document, player_group))
+        return bootstrap_abort(document);
+    if (!data.commander_name.empty())
+    {
+        if (!bootstrap_add_item(document, player_group, "commander_name", data.commander_name))
+            return bootstrap_abort(document);
+    }
+    if (!bootstrap_add_item(document, player_group, "starting_planet_id", data.starting_planet.id))
+        return bootstrap_abort(document);
+    for (size_t index = 0; index < data.player_resources.size(); ++index)
+    {
+        const GameBootstrapResource &resource = data.player_resources[index];
+        ft_string key("resource_");
+        key.append(ft_to_string(resource.resource_id));
+        if (!bootstrap_add_item(document, player_group, key.c_str(), resource.amount))
+            return bootstrap_abort(document);
+    }
+
+    ft_string planet_group_name("planet_");
+    planet_group_name.append(ft_to_string(data.starting_planet.id));
+    json_group *planet_group = document.create_group(planet_group_name.c_str());
+    if (!bootstrap_append_group(document, planet_group))
+        return bootstrap_abort(document);
+    if (!bootstrap_add_item(document, planet_group, "id", data.starting_planet.id))
+        return bootstrap_abort(document);
+    for (size_t index = 0; index < data.starting_planet.resources.size(); ++index)
+    {
+        const GameBootstrapPlanetResource &resource = data.starting_planet.resources[index];
+        ft_string amount_key("resource_");
+        amount_key.append(ft_to_string(resource.resource_id));
+        if (!bootstrap_add_item(document, planet_group, amount_key.c_str(), resource.amount))
+            return bootstrap_abort(document);
+        ft_string rate_key("rate_");
+        rate_key.append(ft_to_string(resource.resource_id));
+        const long scaled_rate = bootstrap_scale_double(resource.rate);
+        ft_string rate_value = ft_to_string(scaled_rate);
+        if (!bootstrap_add_item(document, planet_group, rate_key.c_str(), rate_value))
+            return bootstrap_abort(document);
+    }
+
+    char *serialized = document.write_to_string();
+    if (serialized == ft_nullptr)
+        return bootstrap_abort(document);
+    ft_string result(serialized);
+    cma_free(serialized);
+    return result;
+}
+
+bool game_bootstrap_write_quicksave(const GameBootstrapData &data, const char *file_path) noexcept
+{
+    if (file_path == ft_nullptr)
+        return false;
+    const ft_string serialized = game_bootstrap_serialize(data);
+    if (serialized.empty())
+        return false;
+
+    ft_ofstream stream;
+    if (stream.open(file_path) != 0)
+        return false;
+    if (stream.write(serialized.c_str()) < 0)
+    {
+        stream.close();
+        return false;
+    }
+    stream.write("\n");
+    stream.close();
+    return true;
+}
+
+bool game_bootstrap_create_quicksave_with_commander(const char *file_path, const ft_string &commander_name) noexcept
+{
+    GameBootstrapData data;
+    if (!game_bootstrap_initialize_with_commander(data, commander_name))
+        return false;
+    return game_bootstrap_write_quicksave(data, file_path);
+}
+
+bool game_bootstrap_create_default_quicksave(const char *file_path) noexcept
+{
+    const ft_string default_name("Commander");
+    return game_bootstrap_create_quicksave_with_commander(file_path, default_name);
+}

--- a/src/game_bootstrap.hpp
+++ b/src/game_bootstrap.hpp
@@ -1,0 +1,53 @@
+#ifndef GAME_BOOTSTRAP_HPP
+#define GAME_BOOTSTRAP_HPP
+
+#include "planets.hpp"
+#include "../libft/Template/vector.hpp"
+#include "../libft/Libft/libft.hpp"
+
+struct GameBootstrapResource
+{
+    int resource_id;
+    int amount;
+
+    GameBootstrapResource() noexcept : resource_id(0), amount(0) {}
+    GameBootstrapResource(int id, int value) noexcept : resource_id(id), amount(value) {}
+};
+
+struct GameBootstrapPlanetResource
+{
+    int resource_id;
+    int amount;
+    double rate;
+
+    GameBootstrapPlanetResource() noexcept : resource_id(0), amount(0), rate(0.0) {}
+    GameBootstrapPlanetResource(int id, int value, double production_rate) noexcept
+        : resource_id(id), amount(value), rate(production_rate)
+    {}
+};
+
+struct GameBootstrapPlanet
+{
+    int                                           id;
+    ft_vector<GameBootstrapPlanetResource>        resources;
+
+    GameBootstrapPlanet() noexcept : id(0), resources() {}
+};
+
+struct GameBootstrapData
+{
+    ft_string                    commander_name;
+    GameBootstrapPlanet          starting_planet;
+    ft_vector<GameBootstrapResource> player_resources;
+
+    GameBootstrapData() noexcept : commander_name(), starting_planet(), player_resources() {}
+};
+
+bool      game_bootstrap_initialize_default(GameBootstrapData &out_data) noexcept;
+bool      game_bootstrap_initialize_with_commander(GameBootstrapData &out_data, const ft_string &commander_name) noexcept;
+ft_string game_bootstrap_serialize(const GameBootstrapData &data) noexcept;
+bool      game_bootstrap_write_quicksave(const GameBootstrapData &data, const char *file_path) noexcept;
+bool      game_bootstrap_create_default_quicksave(const char *file_path) noexcept;
+bool      game_bootstrap_create_quicksave_with_commander(const char *file_path, const ft_string &commander_name) noexcept;
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,548 @@
-#include "game.hpp"
+#include "ui_menu.hpp"
+#include "game_bootstrap.hpp"
+#include "player_profile.hpp"
+
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+#include <SFML/Config.hpp>
+#include <SFML/Graphics.hpp>
+
+#include <cstddef>
+
+namespace
+{
+    constexpr unsigned int kVirtualReferenceWidth = 1280U;
+    constexpr unsigned int      kVirtualReferenceHeight = 720U;
+    ft_string                    g_commander_name;
+    PlayerProfilePreferences     g_active_profile;
+
+    float compute_axis_scale(unsigned int actual_extent, unsigned int reference_extent);
+
+    void render_name_prompt(sf::RenderWindow &window, const sf::Font &font, const ft_string &current_input)
+    {
+        window.clear(sf::Color::Black);
+
+        const sf::Vector2u window_size = window.getSize();
+        const float        half_width = static_cast<float>(window_size.x) / 2.0f;
+        const float        half_height = static_cast<float>(window_size.y) / 2.0f;
+        const float        scale_y = compute_axis_scale(window_size.y, kVirtualReferenceHeight);
+
+        float prompt_size_f = 40.0f * scale_y;
+        if (prompt_size_f < 20.0f)
+            prompt_size_f = 20.0f;
+        const unsigned int prompt_size = static_cast<unsigned int>(prompt_size_f + 0.5f);
+
+        sf::Text prompt_text;
+        prompt_text.setFont(font);
+        prompt_text.setString("Enter Commander Name");
+        prompt_text.setCharacterSize(prompt_size);
+        prompt_text.setFillColor(sf::Color::White);
+        const sf::FloatRect prompt_bounds = prompt_text.getLocalBounds();
+        prompt_text.setOrigin(prompt_bounds.left + prompt_bounds.width / 2.0f, prompt_bounds.top + prompt_bounds.height / 2.0f);
+        prompt_text.setPosition(half_width, half_height - (80.0f * scale_y));
+
+        sf::Text input_text;
+        input_text.setFont(font);
+        ft_string display_value = current_input;
+        if (display_value.empty())
+            display_value = ft_string("<Commander>");
+        input_text.setString(display_value.c_str());
+        float input_size_f = 32.0f * scale_y;
+        if (input_size_f < 18.0f)
+            input_size_f = 18.0f;
+        input_text.setCharacterSize(static_cast<unsigned int>(input_size_f + 0.5f));
+        input_text.setFillColor(sf::Color::White);
+        const sf::FloatRect input_bounds = input_text.getLocalBounds();
+        input_text.setOrigin(input_bounds.left + input_bounds.width / 2.0f, input_bounds.top + input_bounds.height / 2.0f);
+        input_text.setPosition(half_width, half_height);
+
+        sf::Text hint_text;
+        hint_text.setFont(font);
+        hint_text.setString("Press Enter to confirm");
+        float hint_size_f = 20.0f * scale_y;
+        if (hint_size_f < 14.0f)
+            hint_size_f = 14.0f;
+        hint_text.setCharacterSize(static_cast<unsigned int>(hint_size_f + 0.5f));
+        hint_text.setFillColor(sf::Color(180, 180, 180));
+        const sf::FloatRect hint_bounds = hint_text.getLocalBounds();
+        hint_text.setOrigin(hint_bounds.left + hint_bounds.width / 2.0f, hint_bounds.top + hint_bounds.height / 2.0f);
+        hint_text.setPosition(half_width, half_height + (60.0f * scale_y));
+
+        window.draw(prompt_text);
+        window.draw(input_text);
+        window.draw(hint_text);
+        window.display();
+    }
+
+    ft_string prompt_for_commander_name(sf::RenderWindow &window, const sf::Font &font)
+    {
+        ft_string input_value;
+
+        while (window.isOpen())
+        {
+            bool confirm_requested = false;
+
+            sf::Event event;
+            while (window.pollEvent(event))
+            {
+                if (event.type == sf::Event::Closed)
+                {
+                    window.close();
+                }
+                else if (event.type == sf::Event::Resized)
+                {
+                    unsigned int width = event.size.width;
+                    unsigned int height = event.size.height;
+
+                    if (width == 0U)
+                        width = 1U;
+                    if (height == 0U)
+                        height = 1U;
+
+                    const sf::Vector2u adjusted_size(width, height);
+                    sf::View            updated_view(sf::FloatRect(0.0f, 0.0f, static_cast<float>(adjusted_size.x), static_cast<float>(adjusted_size.y)));
+                    window.setView(updated_view);
+                }
+                else if (event.type == sf::Event::TextEntered)
+                {
+                    const sf::Uint32 code_point = event.text.unicode;
+                    if (code_point == 8U)
+                    {
+                        if (!input_value.empty())
+                            input_value.resize(input_value.size() - 1U);
+                    }
+                    else if (code_point == 13U)
+                    {
+                        confirm_requested = true;
+                    }
+                    else if (code_point >= 32U && code_point < 127U)
+                    {
+                        input_value.push_back(static_cast<char>(code_point));
+                    }
+                }
+                else if (event.type == sf::Event::KeyPressed)
+                {
+                    if (event.key.code == sf::Keyboard::Escape)
+                        window.close();
+                    else if (event.key.code == sf::Keyboard::Return)
+                        confirm_requested = true;
+                    else if (event.key.code == sf::Keyboard::BackSpace)
+                    {
+                        if (!input_value.empty())
+                            input_value.resize(input_value.size() - 1U);
+                    }
+                }
+            }
+
+            if (!window.isOpen())
+                break;
+
+            if (confirm_requested)
+            {
+                if (input_value.empty())
+                    return ft_string("Commander");
+                return input_value;
+            }
+
+            render_name_prompt(window, font, input_value);
+        }
+
+        return ft_string();
+    }
+
+    float compute_axis_scale(unsigned int actual_extent, unsigned int reference_extent)
+    {
+        if (reference_extent == 0U)
+            return 1.0f;
+        return static_cast<float>(actual_extent) / static_cast<float>(reference_extent);
+    }
+
+    ft_rect scale_virtual_rect(const ft_rect &virtual_rect, const sf::Vector2u &window_size)
+    {
+        const float scale_x = compute_axis_scale(window_size.x, kVirtualReferenceWidth);
+        const float scale_y = compute_axis_scale(window_size.y, kVirtualReferenceHeight);
+
+        const float scaled_left_f = static_cast<float>(virtual_rect.left) * scale_x;
+        const float scaled_top_f = static_cast<float>(virtual_rect.top) * scale_y;
+        const float scaled_width_f = static_cast<float>(virtual_rect.width) * scale_x;
+        const float scaled_height_f = static_cast<float>(virtual_rect.height) * scale_y;
+
+        int scaled_left = static_cast<int>(scaled_left_f + 0.5f);
+        int scaled_top = static_cast<int>(scaled_top_f + 0.5f);
+        int scaled_width = static_cast<int>(scaled_width_f + 0.5f);
+        int scaled_height = static_cast<int>(scaled_height_f + 0.5f);
+
+        if (scaled_width <= 0)
+            scaled_width = 1;
+        if (scaled_height <= 0)
+            scaled_height = 1;
+
+        return ft_rect(scaled_left, scaled_top, scaled_width, scaled_height);
+    }
+
+    ft_vector<ft_menu_item> build_main_menu_items(const sf::Vector2u &window_size)
+    {
+        const int menu_item_width = 360;
+        const int menu_item_height = 56;
+        const int menu_item_spacing = 22;
+        const int menu_origin_y = 220;
+        const int menu_origin_x = static_cast<int>(kVirtualReferenceWidth / 2U) - (menu_item_width / 2);
+
+        const char *identifiers[] = {"new_game", "load", "settings", "swap_profile", "exit"};
+        const char *labels[] = {"New Game", "Load", "Settings", "Swap Profile", "Exit"};
+
+        ft_vector<ft_menu_item> items;
+        items.reserve(5U);
+
+        for (int index = 0; index < 5; ++index)
+        {
+            const int top = menu_origin_y + index * (menu_item_height + menu_item_spacing);
+            const ft_rect virtual_rect(menu_origin_x, top, menu_item_width, menu_item_height);
+            const ft_rect scaled_rect = scale_virtual_rect(virtual_rect, window_size);
+
+            items.push_back(ft_menu_item(
+                ft_string(identifiers[index]),
+                ft_string(labels[index]),
+                scaled_rect));
+        }
+
+        return items;
+    }
+
+    void update_menu_for_window_size(ft_ui_menu &menu, const sf::Vector2u &window_size)
+    {
+        const ft_menu_item *selected_item = menu.get_selected_item();
+        bool                 had_selection = (selected_item != nullptr);
+        ft_string            selected_identifier;
+
+        if (had_selection)
+            selected_identifier = selected_item->identifier;
+
+        ft_vector<ft_menu_item> scaled_items = build_main_menu_items(window_size);
+        menu.set_items(scaled_items);
+
+        if (!had_selection)
+            return;
+
+        const ft_vector<ft_menu_item> &items = menu.get_items();
+        for (size_t index = 0; index < items.size(); ++index)
+        {
+            if (items[index].identifier == selected_identifier)
+            {
+                menu.set_selected_index(static_cast<int>(index));
+                break;
+            }
+        }
+    }
+
+    void apply_profile_window_preferences(sf::RenderWindow &window, ft_ui_menu &menu)
+    {
+        unsigned int desired_width = g_active_profile.window_width;
+        unsigned int desired_height = g_active_profile.window_height;
+
+        const sf::Vector2u current_size = window.getSize();
+        if (desired_width == 0U)
+            desired_width = current_size.x != 0U ? current_size.x : 1280U;
+        if (desired_height == 0U)
+            desired_height = current_size.y != 0U ? current_size.y : 720U;
+
+        sf::Vector2u desired_size(desired_width, desired_height);
+        if (desired_size.x == 0U)
+            desired_size.x = 1U;
+        if (desired_size.y == 0U)
+            desired_size.y = 1U;
+
+        if (desired_size != current_size)
+        {
+            window.setSize(desired_size);
+            sf::View updated_view(sf::FloatRect(0.0f, 0.0f, static_cast<float>(desired_size.x), static_cast<float>(desired_size.y)));
+            window.setView(updated_view);
+        }
+
+        update_menu_for_window_size(menu, window.getSize());
+        const sf::Vector2u applied_size = window.getSize();
+        g_active_profile.window_width = applied_size.x;
+        g_active_profile.window_height = applied_size.y;
+    }
+
+    bool load_profile_for_commander(const ft_string &commander_name, sf::RenderWindow &window, ft_ui_menu &menu)
+    {
+        PlayerProfilePreferences loaded_profile;
+        if (!player_profile_load_or_create(loaded_profile, commander_name))
+        {
+            g_commander_name = commander_name;
+            g_active_profile = PlayerProfilePreferences();
+            g_active_profile.commander_name = g_commander_name;
+            apply_profile_window_preferences(window, menu);
+            return false;
+        }
+
+        g_active_profile = loaded_profile;
+        if (g_active_profile.commander_name.empty())
+            g_active_profile.commander_name = commander_name;
+        g_commander_name = g_active_profile.commander_name;
+        if (g_commander_name.empty())
+            g_commander_name = commander_name;
+
+        apply_profile_window_preferences(window, menu);
+        return true;
+    }
+
+    void persist_active_profile()
+    {
+        if (g_commander_name.empty())
+            return;
+        g_active_profile.commander_name = g_commander_name;
+        player_profile_save(g_active_profile);
+    }
+
+    const sf::Font &resolve_menu_font(sf::Font &owned_font)
+    {
+        const char *font_candidates[] = {
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+            "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+            "/usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf",
+            ft_nullptr
+        };
+
+        size_t index = 0;
+        while (font_candidates[index] != ft_nullptr)
+        {
+            if (owned_font.loadFromFile(font_candidates[index]))
+                return owned_font;
+            ++index;
+        }
+
+#if (SFML_VERSION_MAJOR > 2) || (SFML_VERSION_MAJOR == 2 && SFML_VERSION_MINOR >= 6)
+        return sf::Font::getDefaultFont();
+#else
+        return owned_font;
+#endif
+    }
+
+    void render_menu(sf::RenderWindow &window, const ft_ui_menu &menu, const sf::Font &font, const sf::Vector2u &window_size)
+    {
+        window.clear(sf::Color::Black);
+
+        const ft_vector<ft_menu_item> &items = menu.get_items();
+        const int hovered_index = menu.get_hovered_index();
+        const int selected_index = menu.get_selected_index();
+
+        const float scale_y = compute_axis_scale(window_size.y, kVirtualReferenceHeight);
+        float       character_size_f = 32.0f * scale_y;
+        if (character_size_f < 18.0f)
+            character_size_f = 18.0f;
+        const unsigned int character_size = static_cast<unsigned int>(character_size_f + 0.5f);
+
+        const size_t count = items.size();
+        for (size_t index = 0; index < count; ++index)
+        {
+            const ft_menu_item &item = items[index];
+
+            sf::RectangleShape background_shape;
+            background_shape.setPosition(static_cast<float>(item.bounds.left), static_cast<float>(item.bounds.top));
+            background_shape.setSize(sf::Vector2f(static_cast<float>(item.bounds.width), static_cast<float>(item.bounds.height)));
+
+            const bool is_selected = static_cast<int>(index) == selected_index;
+            const bool is_hovered = static_cast<int>(index) == hovered_index;
+
+            if (is_selected)
+                background_shape.setFillColor(sf::Color(60, 60, 60));
+            else if (is_hovered)
+                background_shape.setFillColor(sf::Color(40, 40, 40));
+            else
+                background_shape.setFillColor(sf::Color(20, 20, 20));
+
+            window.draw(background_shape);
+
+            sf::Text label;
+            label.setFont(font);
+            label.setString(item.label.c_str());
+            label.setCharacterSize(character_size);
+            label.setFillColor(sf::Color::White);
+
+            const sf::FloatRect bounds = label.getLocalBounds();
+            const float origin_x = bounds.left + (bounds.width / 2.0f);
+            const float origin_y = bounds.top + (bounds.height / 2.0f);
+            label.setOrigin(origin_x, origin_y);
+
+            const float position_x = static_cast<float>(item.bounds.left) + static_cast<float>(item.bounds.width) / 2.0f;
+            const float position_y = static_cast<float>(item.bounds.top) + static_cast<float>(item.bounds.height) / 2.0f;
+            label.setPosition(position_x, position_y);
+
+            window.draw(label);
+        }
+
+        window.display();
+    }
+
+    const char *kQuickSavePath = "quicksave.json";
+
+    const ft_menu_item *menu_item_from_index(const ft_ui_menu &menu, int index)
+    {
+        if (index < 0)
+            return ft_nullptr;
+
+        const ft_vector<ft_menu_item> &items = menu.get_items();
+        const size_t unsigned_index = static_cast<size_t>(index);
+        if (unsigned_index >= items.size())
+            return ft_nullptr;
+
+        return &items[unsigned_index];
+    }
+
+    void handle_menu_activation(const ft_menu_item &item, sf::RenderWindow &window, ft_ui_menu &menu, const sf::Font &font)
+    {
+        if (item.identifier == "exit")
+        {
+            window.close();
+            return;
+        }
+
+        if (item.identifier == "new_game")
+        {
+            if (g_commander_name.empty())
+                g_commander_name = ft_string("Commander");
+            game_bootstrap_create_quicksave_with_commander(kQuickSavePath, g_commander_name);
+            return;
+        }
+
+        if (item.identifier == "swap_profile")
+        {
+            ft_string new_commander = prompt_for_commander_name(window, font);
+            if (!window.isOpen())
+                return;
+            if (new_commander.empty())
+                new_commander = ft_string("Commander");
+            if (new_commander == g_commander_name)
+                return;
+            load_profile_for_commander(new_commander, window, menu);
+            persist_active_profile();
+            return;
+        }
+    }
+}
 
 int main()
 {
+    sf::RenderWindow window(sf::VideoMode(1280U, 720U), "Galactic Planet Miner", sf::Style::Default);
+    window.setVerticalSyncEnabled(true);
+    window.setKeyRepeatEnabled(false);
+
+    ft_ui_menu menu;
+    update_menu_for_window_size(menu, window.getSize());
+
+    sf::Font font;
+    const sf::Font &menu_font = resolve_menu_font(font);
+
+    if (window.isOpen())
+    {
+        g_commander_name = prompt_for_commander_name(window, menu_font);
+        if (!window.isOpen())
+            return 0;
+        if (g_commander_name.empty())
+            g_commander_name = ft_string("Commander");
+        load_profile_for_commander(g_commander_name, window, menu);
+        persist_active_profile();
+    }
+
+    while (window.isOpen())
+    {
+        ft_mouse_state mouse_state;
+        ft_keyboard_state keyboard_state;
+        bool confirm_pressed = false;
+
+        sf::Event event;
+        while (window.pollEvent(event))
+        {
+            if (event.type == sf::Event::Closed)
+            {
+                window.close();
+            }
+            else if (event.type == sf::Event::MouseMoved)
+            {
+                mouse_state.moved = true;
+                mouse_state.x = event.mouseMove.x;
+                mouse_state.y = event.mouseMove.y;
+            }
+            else if (event.type == sf::Event::MouseButtonPressed)
+            {
+                if (event.mouseButton.button == sf::Mouse::Left)
+                {
+                    mouse_state.left_pressed = true;
+                    mouse_state.x = event.mouseButton.x;
+                    mouse_state.y = event.mouseButton.y;
+                }
+            }
+            else if (event.type == sf::Event::MouseButtonReleased)
+            {
+                if (event.mouseButton.button == sf::Mouse::Left)
+                {
+                    mouse_state.left_released = true;
+                    mouse_state.x = event.mouseButton.x;
+                    mouse_state.y = event.mouseButton.y;
+                }
+            }
+            else if (event.type == sf::Event::Resized)
+            {
+                unsigned int width = event.size.width;
+                unsigned int height = event.size.height;
+
+                if (width == 0U)
+                    width = 1U;
+                if (height == 0U)
+                    height = 1U;
+
+                const sf::Vector2u adjusted_size(width, height);
+                sf::View            updated_view(sf::FloatRect(0.0f, 0.0f, static_cast<float>(adjusted_size.x), static_cast<float>(adjusted_size.y)));
+                window.setView(updated_view);
+                update_menu_for_window_size(menu, adjusted_size);
+                g_active_profile.window_width = adjusted_size.x;
+                g_active_profile.window_height = adjusted_size.y;
+                persist_active_profile();
+            }
+            else if (event.type == sf::Event::KeyPressed)
+            {
+                if (event.key.code == sf::Keyboard::Up)
+                    keyboard_state.pressed_up = true;
+                else if (event.key.code == sf::Keyboard::Down)
+                    keyboard_state.pressed_down = true;
+                else if (event.key.code == sf::Keyboard::Return || event.key.code == sf::Keyboard::Space)
+                    confirm_pressed = true;
+                else if (event.key.code == sf::Keyboard::Escape)
+                    window.close();
+            }
+        }
+
+        if (!mouse_state.moved)
+        {
+            const sf::Vector2i cursor = sf::Mouse::getPosition(window);
+            mouse_state.x = cursor.x;
+            mouse_state.y = cursor.y;
+        }
+
+        menu.handle_mouse_input(mouse_state);
+        menu.handle_keyboard_input(keyboard_state);
+
+        if (mouse_state.left_pressed)
+        {
+            const int hovered_index = menu.get_hovered_index();
+            const ft_menu_item *hovered_item = menu_item_from_index(menu, hovered_index);
+            if (hovered_item != ft_nullptr)
+                handle_menu_activation(*hovered_item, window, menu, menu_font);
+        }
+
+        if (confirm_pressed)
+        {
+            const ft_menu_item *selected_item = menu.get_selected_item();
+            if (selected_item != ft_nullptr)
+                handle_menu_activation(*selected_item, window, menu, menu_font);
+        }
+
+        render_menu(window, menu, menu_font, window.getSize());
+    }
+
     return 0;
 }

--- a/src/player_profile.cpp
+++ b/src/player_profile.cpp
@@ -1,0 +1,172 @@
+#include "player_profile.hpp"
+
+#include "../libft/CPP_class/class_nullptr.hpp"
+#include "../libft/Libft/libft.hpp"
+#include "../libft/JSon/document.hpp"
+#include "../libft/File/open_dir.hpp"
+
+#include <sys/stat.h>
+
+namespace
+{
+    const char *kProfileDirectory = "profiles";
+    const char *kProfileGroupName = "profile";
+    const char *kProfileExtension = ".prof";
+
+    bool ensure_profile_directory_exists() noexcept
+    {
+        int exists_result = file_dir_exists(kProfileDirectory);
+        if (exists_result == 0)
+            return true;
+        if (exists_result < 0)
+            return false;
+        if (file_create_directory(kProfileDirectory, 0755) != 0)
+            return false;
+        return true;
+    }
+
+    bool add_string(json_document &document, json_group *group, const char *key, const ft_string &value) noexcept
+    {
+        if (group == ft_nullptr || key == ft_nullptr)
+            return false;
+        json_item *item = document.create_item(key, value.c_str());
+        if (item == ft_nullptr)
+            return false;
+        document.add_item(group, item);
+        return true;
+    }
+
+    bool add_int(json_document &document, json_group *group, const char *key, int value) noexcept
+    {
+        if (group == ft_nullptr || key == ft_nullptr)
+            return false;
+        json_item *item = document.create_item(key, value);
+        if (item == ft_nullptr)
+            return false;
+        document.add_item(group, item);
+        return true;
+    }
+
+    bool read_int(json_document &document, json_group *group, const char *key, unsigned int &out_value) noexcept
+    {
+        if (group == ft_nullptr || key == ft_nullptr)
+            return false;
+        json_item *item = document.find_item(group, key);
+        if (item == ft_nullptr || item->value == ft_nullptr)
+            return false;
+        const int parsed = ft_atoi(item->value);
+        if (parsed <= 0)
+            return false;
+        out_value = static_cast<unsigned int>(parsed);
+        return true;
+    }
+
+    ft_string sanitize_commander_name(const ft_string &commander_name) noexcept
+    {
+        const char *raw = commander_name.c_str();
+        if (raw == ft_nullptr)
+            return ft_string("Commander");
+
+        ft_string sanitized;
+        for (size_t index = 0; raw[index] != '\0'; ++index)
+        {
+            const char character = raw[index];
+            const bool is_digit = (character >= '0' && character <= '9');
+            const bool is_upper = (character >= 'A' && character <= 'Z');
+            const bool is_lower = (character >= 'a' && character <= 'z');
+            const bool is_allowed_symbol = (character == '-' || character == '_' || character == ' ');
+            const bool is_forbidden = (character == '/' || character == '\\' || character == ':' || character == '*' ||
+                                       character == '?' || character == '"' || character == '<' || character == '>' ||
+                                       character == '|');
+
+            if ((is_digit || is_upper || is_lower || is_allowed_symbol) && !is_forbidden)
+                sanitized.append(character);
+            else
+                sanitized.append('_');
+        }
+
+        if (sanitized.empty())
+            sanitized = ft_string("Commander");
+        return sanitized;
+    }
+}
+
+ft_string player_profile_resolve_path(const ft_string &commander_name) noexcept
+{
+    ft_string sanitized = sanitize_commander_name(commander_name);
+    if (sanitized.empty())
+        return ft_string();
+
+    ft_string path(kProfileDirectory);
+    path.append("/");
+    path.append(sanitized);
+    path.append(kProfileExtension);
+    return path;
+}
+
+bool player_profile_save(const PlayerProfilePreferences &preferences) noexcept
+{
+    if (preferences.commander_name.empty())
+        return false;
+    if (!ensure_profile_directory_exists())
+        return false;
+
+    ft_string path = player_profile_resolve_path(preferences.commander_name);
+    if (path.empty())
+        return false;
+
+    json_document document;
+    json_group *group = document.create_group(kProfileGroupName);
+    if (group == ft_nullptr)
+        return false;
+    document.append_group(group);
+
+    if (!add_string(document, group, "commander_name", preferences.commander_name))
+        return false;
+    const unsigned int stored_width = preferences.window_width == 0U ? 1280U : preferences.window_width;
+    const unsigned int stored_height = preferences.window_height == 0U ? 720U : preferences.window_height;
+    if (!add_int(document, group, "window_width", static_cast<int>(stored_width)))
+        return false;
+    if (!add_int(document, group, "window_height", static_cast<int>(stored_height)))
+        return false;
+
+    if (document.write_to_file(path.c_str()) != 0)
+        return false;
+    return true;
+}
+
+bool player_profile_load_or_create(PlayerProfilePreferences &out_preferences, const ft_string &commander_name) noexcept
+{
+    out_preferences = PlayerProfilePreferences();
+    out_preferences.commander_name = commander_name;
+
+    if (commander_name.empty())
+        return false;
+    if (!ensure_profile_directory_exists())
+        return false;
+
+    ft_string path = player_profile_resolve_path(commander_name);
+    if (path.empty())
+        return false;
+
+    json_document document;
+    if (document.read_from_file(path.c_str()) != 0)
+        return player_profile_save(out_preferences);
+
+    json_group *group = document.find_group(kProfileGroupName);
+    if (group == ft_nullptr)
+        return player_profile_save(out_preferences);
+
+    json_item *name_item = document.find_item(group, "commander_name");
+    if (name_item != ft_nullptr && name_item->value != ft_nullptr)
+        out_preferences.commander_name = ft_string(name_item->value);
+
+    unsigned int parsed_width = out_preferences.window_width;
+    unsigned int parsed_height = out_preferences.window_height;
+    read_int(document, group, "window_width", parsed_width);
+    read_int(document, group, "window_height", parsed_height);
+
+    out_preferences.window_width = parsed_width;
+    out_preferences.window_height = parsed_height;
+    return true;
+}

--- a/src/player_profile.hpp
+++ b/src/player_profile.hpp
@@ -1,0 +1,19 @@
+#ifndef PLAYER_PROFILE_HPP
+#define PLAYER_PROFILE_HPP
+
+#include "../libft/CPP_class/class_string_class.hpp"
+
+struct PlayerProfilePreferences
+{
+    ft_string    commander_name;
+    unsigned int window_width;
+    unsigned int window_height;
+
+    PlayerProfilePreferences() noexcept : commander_name(), window_width(1280U), window_height(720U) {}
+};
+
+bool player_profile_load_or_create(PlayerProfilePreferences &out_preferences, const ft_string &commander_name) noexcept;
+bool player_profile_save(const PlayerProfilePreferences &preferences) noexcept;
+ft_string player_profile_resolve_path(const ft_string &commander_name) noexcept;
+
+#endif


### PR DESCRIPTION
## Summary
- add a player profile module that persists commander preferences and window dimensions per profile file
- integrate profile loading/saving into the main menu, including a swap profile option and automatic window size persistence
- register the new profile source file with the build configuration

## Testing
- `make` *(fails: SFML development libraries not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c493d2b48331b73e4634ef51211e