### PR TITLE
Refactor main menu profile flows into dedicated modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ SRC_COMMON  = \
     $(SRC_DIR)/combat_tick.cpp \
     $(SRC_DIR)/game_bootstrap.cpp \
     $(SRC_DIR)/player_profile.cpp \
+    $(SRC_DIR)/font_util.cpp \
+    $(SRC_DIR)/main_menu.cpp \
     $(SRC_DIR)/quests.cpp \
     $(SRC_DIR)/research.cpp \
     $(SRC_DIR)/game_research.cpp \
@@ -34,7 +36,10 @@ SRC_COMMON  = \
     $(SRC_DIR)/game.cpp \
     $(SRC_DIR)/save_system.cpp \
     $(SRC_DIR)/ui_input.cpp \
-    $(SRC_DIR)/ui_menu.cpp
+    $(SRC_DIR)/ui_menu.cpp \
+    $(SRC_DIR)/profile_entry_flow.cpp \
+    $(SRC_DIR)/profile_management_flow.cpp \
+    $(SRC_DIR)/profile_preferences.cpp
 SRC_MAIN    = $(SRC_DIR)/main.cpp
 SRC         = $(SRC_COMMON) $(SRC_MAIN)
 SRC_TEST    = $(SRC_COMMON) \

--- a/src/app_constants.hpp
+++ b/src/app_constants.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace app_constants
+{
+    constexpr unsigned int kWindowWidth = 1280U;
+    constexpr unsigned int kWindowHeight = 720U;
+}
+

--- a/src/font_util.cpp
+++ b/src/font_util.cpp
@@ -1,0 +1,90 @@
+#include "main_menu_system.hpp"
+
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+namespace
+{
+    struct font_cache_entry
+    {
+        int       size;
+        TTF_Font *font;
+        bool      attempted;
+    };
+}
+
+TTF_Font *resolve_font(int point_size)
+{
+    static font_cache_entry font_cache[] = {
+        {48, ft_nullptr, false},
+        {28, ft_nullptr, false}
+    };
+
+    for (size_t index = 0; index < sizeof(font_cache) / sizeof(font_cache[0]); ++index)
+    {
+        font_cache_entry &entry = font_cache[index];
+        if (entry.size != point_size)
+            continue;
+
+        if (!entry.attempted)
+        {
+            entry.attempted = true;
+
+            const char *font_paths[] = {
+                "fonts/DejaVuSans.ttf",
+                "fonts/LiberationSans-Regular.ttf",
+                "assets/fonts/DejaVuSans.ttf",
+                "assets/fonts/LiberationSans-Regular.ttf",
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+                "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+                "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+                "/usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf",
+                "/System/Library/Fonts/SFNSDisplay.ttf",
+                "/System/Library/Fonts/Supplemental/Arial.ttf",
+                "/Library/Fonts/Arial.ttf",
+                "C:/Windows/Fonts/segoeui.ttf",
+                "C:/Windows/Fonts/arial.ttf",
+                "C:/Windows/Fonts/calibri.ttf"
+            };
+
+            const size_t path_count = sizeof(font_paths) / sizeof(font_paths[0]);
+            for (size_t path_index = 0; path_index < path_count; ++path_index)
+            {
+                const char *path = font_paths[path_index];
+                if (path == ft_nullptr)
+                    continue;
+
+                entry.font = TTF_OpenFont(path, point_size);
+                if (entry.font != ft_nullptr)
+                    break;
+            }
+        }
+
+        return entry.font;
+    }
+
+    return ft_nullptr;
+}
+
+SDL_Texture *create_text_texture(SDL_Renderer &renderer, TTF_Font &font, const ft_string &text,
+    const SDL_Color &color, SDL_Rect &out_rect)
+{
+    if (text.c_str() == ft_nullptr)
+        return ft_nullptr;
+
+    SDL_Surface *surface = TTF_RenderUTF8_Blended(&font, text.c_str(), color);
+    if (surface == ft_nullptr)
+        return ft_nullptr;
+
+    SDL_Texture *texture = SDL_CreateTextureFromSurface(&renderer, surface);
+    if (texture != ft_nullptr)
+    {
+        out_rect.x = 0;
+        out_rect.y = 0;
+        out_rect.w = surface->w;
+        out_rect.h = surface->h;
+    }
+
+    SDL_FreeSurface(surface);
+    return texture;
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,8 @@
-#include "ui_menu.hpp"
+#include "app_constants.hpp"
+#include "main_menu_system.hpp"
 #include "player_profile.hpp"
+#include "ui_input.hpp"
+#include "ui_menu.hpp"
 
 #include "../libft/CPP_class/class_nullptr.hpp"
 #include "../libft/Libft/libft.hpp"
@@ -9,154 +12,6 @@
 
 namespace
 {
-    constexpr unsigned int kWindowWidth = 1280U;
-    constexpr unsigned int kWindowHeight = 720U;
-    static const unsigned int kMaxProfileNameLength = 24U;
-
-    enum e_profile_append_result
-    {
-        PROFILE_APPEND_REJECTED = 0,
-        PROFILE_APPEND_ACCEPTED = 1,
-        PROFILE_APPEND_MAX_LENGTH = 2
-    };
-
-    bool is_profile_character_allowed(char character) noexcept
-    {
-        const bool is_lower = (character >= 'a' && character <= 'z');
-        const bool is_upper = (character >= 'A' && character <= 'Z');
-        const bool is_digit = (character >= '0' && character <= '9');
-        return is_lower || is_upper || is_digit;
-    }
-
-    e_profile_append_result append_profile_character(ft_string &profile_name, char character) noexcept
-    {
-        if (!is_profile_character_allowed(character))
-            return PROFILE_APPEND_REJECTED;
-
-        if (profile_name.size() >= static_cast<size_t>(kMaxProfileNameLength))
-            return PROFILE_APPEND_MAX_LENGTH;
-
-        profile_name.append(character);
-        return PROFILE_APPEND_ACCEPTED;
-    }
-
-    void remove_last_profile_character(ft_string &profile_name) noexcept
-    {
-        const size_t current_size = profile_name.size();
-        if (current_size == 0U)
-            return;
-        profile_name.erase(current_size - 1U, 1U);
-    }
-
-    bool profile_name_is_valid(const ft_string &profile_name) noexcept
-    {
-        return !profile_name.empty();
-    }
-
-    bool save_profile_preferences(SDL_Window *window, const ft_string &profile_name) noexcept
-    {
-        if (window == ft_nullptr)
-            return false;
-
-        PlayerProfilePreferences preferences;
-        preferences.commander_name = profile_name;
-
-        int window_width = static_cast<int>(kWindowWidth);
-        int window_height = static_cast<int>(kWindowHeight);
-        SDL_GetWindowSize(window, &window_width, &window_height);
-
-        if (window_width > 0)
-            preferences.window_width = static_cast<unsigned int>(window_width);
-        if (window_height > 0)
-            preferences.window_height = static_cast<unsigned int>(window_height);
-
-        return player_profile_save(preferences);
-    }
-
-    ft_vector<ft_menu_item> build_main_menu_items()
-    {
-        const ft_rect base_rect(460, 220, 360, 56);
-        const int      spacing = 22;
-
-        const char *identifiers[] = {"new_game", "load", "settings", "swap_profile", "exit"};
-        const char *labels[] = {"New Game", "Load", "Settings", "Swap Profile", "Exit"};
-
-        ft_vector<ft_menu_item> items;
-        items.reserve(5U);
-
-        for (int index = 0; index < 5; ++index)
-        {
-            ft_rect item_rect = base_rect;
-            item_rect.top += index * (base_rect.height + spacing);
-            items.push_back(ft_menu_item(
-                ft_string(identifiers[index]),
-                ft_string(labels[index]),
-                item_rect));
-        }
-
-        return items;
-    }
-
-    TTF_Font *resolve_font(int point_size)
-    {
-        struct font_cache_entry
-        {
-            int       size;
-            TTF_Font *font;
-            bool      attempted;
-        };
-
-        static font_cache_entry font_cache[] = {
-            {48, ft_nullptr, false},
-            {28, ft_nullptr, false}
-        };
-
-        for (size_t index = 0; index < sizeof(font_cache) / sizeof(font_cache[0]); ++index)
-        {
-            font_cache_entry &entry = font_cache[index];
-            if (entry.size != point_size)
-                continue;
-
-            if (!entry.attempted)
-            {
-                entry.attempted = true;
-
-                const char *font_paths[] = {
-                    "fonts/DejaVuSans.ttf",
-                    "fonts/LiberationSans-Regular.ttf",
-                    "assets/fonts/DejaVuSans.ttf",
-                    "assets/fonts/LiberationSans-Regular.ttf",
-                    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-                    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
-                    "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
-                    "/usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf",
-                    "/System/Library/Fonts/SFNSDisplay.ttf",
-                    "/System/Library/Fonts/Supplemental/Arial.ttf",
-                    "/Library/Fonts/Arial.ttf",
-                    "C:/Windows/Fonts/segoeui.ttf",
-                    "C:/Windows/Fonts/arial.ttf",
-                    "C:/Windows/Fonts/calibri.ttf"
-                };
-
-                const size_t path_count = sizeof(font_paths) / sizeof(font_paths[0]);
-                for (size_t path_index = 0; path_index < path_count; ++path_index)
-                {
-                    const char *path = font_paths[path_index];
-                    if (path == ft_nullptr)
-                        continue;
-
-                    entry.font = TTF_OpenFont(path, point_size);
-                    if (entry.font != ft_nullptr)
-                        break;
-                }
-            }
-
-            return entry.font;
-        }
-
-        return ft_nullptr;
-    }
-
     const ft_menu_item *menu_item_from_index(const ft_ui_menu &menu, int index)
     {
         if (index < 0)
@@ -172,355 +27,16 @@ namespace
         return &items[converted_index];
     }
 
-    void handle_menu_activation(const ft_menu_item &item, bool &running)
+    void destroy_renderer(SDL_Renderer *renderer)
     {
-        if (item.identifier == "exit")
-            running = false;
+        if (renderer != ft_nullptr)
+            SDL_DestroyRenderer(renderer);
     }
 
-    SDL_Texture *create_text_texture(SDL_Renderer &renderer, TTF_Font &font, const ft_string &text, const SDL_Color &color, SDL_Rect &out_rect)
+    void destroy_window(SDL_Window *window)
     {
-        if (text.c_str() == ft_nullptr)
-            return ft_nullptr;
-
-        SDL_Surface *surface = TTF_RenderUTF8_Blended(&font, text.c_str(), color);
-        if (surface == ft_nullptr)
-            return ft_nullptr;
-
-        SDL_Texture *texture = SDL_CreateTextureFromSurface(&renderer, surface);
-        if (texture != ft_nullptr)
-        {
-            out_rect.x = 0;
-            out_rect.y = 0;
-            out_rect.w = surface->w;
-            out_rect.h = surface->h;
-        }
-
-        SDL_FreeSurface(surface);
-        return texture;
-    }
-
-    void render_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *title_font, TTF_Font *menu_font, int window_width, int window_height, const ft_string &active_profile_name)
-    {
-        SDL_SetRenderDrawColor(&renderer, 12, 16, 28, 255);
-        SDL_RenderClear(&renderer);
-
-        int output_width = window_width;
-        int output_height = window_height;
-        SDL_GetRendererOutputSize(&renderer, &output_width, &output_height);
-
-        if (title_font != ft_nullptr)
-        {
-            SDL_Color title_color = {220, 220, 245, 255};
-            SDL_Rect  title_rect;
-            SDL_Texture *title_texture = create_text_texture(renderer, *title_font, ft_string("Galactic Planet Miner"), title_color, title_rect);
-            if (title_texture != ft_nullptr)
-            {
-                title_rect.x = output_width / 2 - title_rect.w / 2;
-                title_rect.y = 96;
-                SDL_RenderCopy(&renderer, title_texture, ft_nullptr, &title_rect);
-                SDL_DestroyTexture(title_texture);
-            }
-        }
-
-        if (menu_font != ft_nullptr && !active_profile_name.empty())
-        {
-            ft_string profile_label("Profile: ");
-            profile_label.append(active_profile_name);
-
-            SDL_Color profile_color = {200, 210, 230, 255};
-            SDL_Rect  profile_rect;
-            SDL_Texture *profile_texture = create_text_texture(renderer, *menu_font, profile_label, profile_color, profile_rect);
-            if (profile_texture != ft_nullptr)
-            {
-                profile_rect.x = output_width / 2 - profile_rect.w / 2;
-                profile_rect.y = 164;
-                SDL_RenderCopy(&renderer, profile_texture, ft_nullptr, &profile_rect);
-                SDL_DestroyTexture(profile_texture);
-            }
-        }
-
-        const ft_vector<ft_menu_item> &items = menu.get_items();
-        const int hovered_index = menu.get_hovered_index();
-        const int selected_index = menu.get_selected_index();
-
-        for (size_t index = 0; index < items.size(); ++index)
-        {
-            const ft_menu_item &item = items[index];
-
-            const bool is_hovered = static_cast<int>(index) == hovered_index;
-            const bool is_selected = static_cast<int>(index) == selected_index;
-
-            const Uint8 r = is_hovered ? 56 : (is_selected ? 40 : 28);
-            const Uint8 g = is_hovered ? 84 : (is_selected ? 64 : 36);
-            const Uint8 b = is_hovered ? 140 : (is_selected ? 112 : 60);
-
-            SDL_Rect button_rect;
-            button_rect.x = item.bounds.left;
-            button_rect.y = item.bounds.top;
-            button_rect.w = item.bounds.width;
-            button_rect.h = item.bounds.height;
-
-            SDL_SetRenderDrawColor(&renderer, r, g, b, 255);
-            SDL_RenderFillRect(&renderer, &button_rect);
-
-            SDL_SetRenderDrawColor(&renderer, 90, 110, 160, 255);
-            SDL_RenderDrawRect(&renderer, &button_rect);
-
-            if (menu_font != ft_nullptr)
-            {
-                SDL_Color text_color = {255, 255, 255, 255};
-                SDL_Rect  text_rect;
-                SDL_Texture *text_texture = create_text_texture(renderer, *menu_font, item.label, text_color, text_rect);
-                if (text_texture != ft_nullptr)
-                {
-                    text_rect.x = item.bounds.left + (item.bounds.width - text_rect.w) / 2;
-                    text_rect.y = item.bounds.top + (item.bounds.height - text_rect.h) / 2;
-                    SDL_RenderCopy(&renderer, text_texture, ft_nullptr, &text_rect);
-                    SDL_DestroyTexture(text_texture);
-                }
-            }
-        }
-
-        SDL_RenderPresent(&renderer);
-    }
-
-    void render_profile_entry_screen(SDL_Renderer &renderer, TTF_Font *title_font, TTF_Font *menu_font, const ft_string &profile_name, const ft_string &status_message, bool status_is_error)
-    {
-        SDL_SetRenderDrawColor(&renderer, 12, 16, 28, 255);
-        SDL_RenderClear(&renderer);
-
-        int output_width = static_cast<int>(kWindowWidth);
-        int output_height = static_cast<int>(kWindowHeight);
-        SDL_GetRendererOutputSize(&renderer, &output_width, &output_height);
-
-        if (title_font != ft_nullptr)
-        {
-            SDL_Color title_color = {220, 220, 245, 255};
-            SDL_Rect  title_rect;
-            SDL_Texture *title_texture = create_text_texture(renderer, *title_font, ft_string("Commander Profile"), title_color, title_rect);
-            if (title_texture != ft_nullptr)
-            {
-                title_rect.x = output_width / 2 - title_rect.w / 2;
-                title_rect.y = 96;
-                SDL_RenderCopy(&renderer, title_texture, ft_nullptr, &title_rect);
-                SDL_DestroyTexture(title_texture);
-            }
-        }
-
-        SDL_Rect input_rect;
-        input_rect.w = 520;
-        input_rect.h = 68;
-        input_rect.x = output_width / 2 - input_rect.w / 2;
-        input_rect.y = output_height / 2 - input_rect.h / 2;
-
-        SDL_SetRenderDrawColor(&renderer, 18, 24, 44, 240);
-        SDL_RenderFillRect(&renderer, &input_rect);
-        SDL_SetRenderDrawColor(&renderer, 90, 110, 160, 255);
-        SDL_RenderDrawRect(&renderer, &input_rect);
-
-        int caret_x = input_rect.x + 18;
-
-        if (menu_font != ft_nullptr)
-        {
-            bool is_placeholder = profile_name.empty();
-            ft_string display_text;
-            if (is_placeholder)
-                display_text = ft_string("Enter profile name");
-            else
-                display_text = profile_name;
-
-            SDL_Color text_color;
-            if (is_placeholder)
-            {
-                text_color.r = 140;
-                text_color.g = 150;
-                text_color.b = 170;
-                text_color.a = 255;
-            }
-            else
-            {
-                text_color.r = 230;
-                text_color.g = 235;
-                text_color.b = 245;
-                text_color.a = 255;
-            }
-
-            SDL_Rect text_rect;
-            SDL_Texture *text_texture = create_text_texture(renderer, *menu_font, display_text, text_color, text_rect);
-            if (text_texture != ft_nullptr)
-            {
-                text_rect.x = input_rect.x + 18;
-                text_rect.y = input_rect.y + (input_rect.h - text_rect.h) / 2;
-                SDL_RenderCopy(&renderer, text_texture, ft_nullptr, &text_rect);
-                caret_x = text_rect.x + text_rect.w + 4;
-                SDL_DestroyTexture(text_texture);
-            }
-
-            if (!is_placeholder)
-            {
-                SDL_Rect caret_rect;
-                caret_rect.x = caret_x;
-                caret_rect.y = input_rect.y + 8;
-                caret_rect.w = 2;
-                caret_rect.h = input_rect.h - 16;
-                SDL_SetRenderDrawColor(&renderer, 210, 220, 250, 255);
-                SDL_RenderFillRect(&renderer, &caret_rect);
-            }
-
-            ft_string instructions("Letters and numbers only. Press Enter to confirm.");
-            SDL_Color instruction_color = {170, 180, 210, 255};
-            SDL_Rect  instruction_rect;
-            SDL_Texture *instruction_texture = create_text_texture(renderer, *menu_font, instructions, instruction_color, instruction_rect);
-            if (instruction_texture != ft_nullptr)
-            {
-                instruction_rect.x = output_width / 2 - instruction_rect.w / 2;
-                instruction_rect.y = input_rect.y + input_rect.h + 36;
-                SDL_RenderCopy(&renderer, instruction_texture, ft_nullptr, &instruction_rect);
-                SDL_DestroyTexture(instruction_texture);
-            }
-
-            if (!status_message.empty())
-            {
-                SDL_Color status_color;
-                if (status_is_error)
-                {
-                    status_color.r = 220;
-                    status_color.g = 90;
-                    status_color.b = 90;
-                    status_color.a = 255;
-                }
-                else
-                {
-                    status_color.r = 180;
-                    status_color.g = 200;
-                    status_color.b = 220;
-                    status_color.a = 255;
-                }
-
-                SDL_Rect status_rect;
-                SDL_Texture *status_texture = create_text_texture(renderer, *menu_font, status_message, status_color, status_rect);
-                if (status_texture != ft_nullptr)
-                {
-                    status_rect.x = output_width / 2 - status_rect.w / 2;
-                    status_rect.y = input_rect.y + input_rect.h + 80;
-                    SDL_RenderCopy(&renderer, status_texture, ft_nullptr, &status_rect);
-                    SDL_DestroyTexture(status_texture);
-                }
-            }
-        }
-
-        SDL_RenderPresent(&renderer);
-    }
-
-    ft_string run_profile_entry_flow(SDL_Window *window, SDL_Renderer *renderer, TTF_Font *title_font, TTF_Font *menu_font)
-    {
-        if (window == ft_nullptr || renderer == ft_nullptr)
-            return ft_string();
-
-        ft_string profile_name;
-        ft_string status_message;
-        bool status_is_error = false;
-        bool running = true;
-        bool accepted = false;
-
-        SDL_StartTextInput();
-
-        while (running && !accepted)
-        {
-            SDL_Event event;
-            while (SDL_PollEvent(&event) == 1)
-            {
-                if (event.type == SDL_QUIT)
-                {
-                    running = false;
-                }
-                else if (event.type == SDL_KEYDOWN)
-                {
-                    if (event.key.keysym.sym == SDLK_ESCAPE)
-                    {
-                        running = false;
-                    }
-                    else if (event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER)
-                    {
-                        if (!profile_name_is_valid(profile_name))
-                        {
-                            status_message = ft_string("Please enter a profile name.");
-                            status_is_error = true;
-                        }
-                        else if (save_profile_preferences(window, profile_name))
-                        {
-                            accepted = true;
-                        }
-                        else
-                        {
-                            status_message = ft_string("Unable to save profile. Check write permissions.");
-                            status_is_error = true;
-                        }
-                    }
-                    else if (event.key.keysym.sym == SDLK_BACKSPACE)
-                    {
-                        remove_last_profile_character(profile_name);
-                        status_message.clear();
-                        status_is_error = false;
-                    }
-                }
-                else if (event.type == SDL_TEXTINPUT)
-                {
-                    const char *text = event.text.text;
-                    if (text != ft_nullptr)
-                    {
-                        bool appended_character = false;
-                        bool rejected_for_length = false;
-                        bool rejected_for_invalid = false;
-
-                        for (int index = 0; text[index] != '\0'; ++index)
-                        {
-                            const char character = text[index];
-                            const e_profile_append_result result = append_profile_character(profile_name, character);
-                            if (result == PROFILE_APPEND_ACCEPTED)
-                            {
-                                appended_character = true;
-                            }
-                            else if (result == PROFILE_APPEND_MAX_LENGTH)
-                            {
-                                rejected_for_length = true;
-                            }
-                            else
-                            {
-                                rejected_for_invalid = true;
-                            }
-                        }
-
-                        if (appended_character)
-                        {
-                            status_message.clear();
-                            status_is_error = false;
-                        }
-                        else if (rejected_for_length)
-                        {
-                            status_message = ft_string("Profile names are limited to 24 characters.");
-                            status_is_error = true;
-                        }
-                        else if (rejected_for_invalid)
-                        {
-                            status_message = ft_string("Use letters and numbers only.");
-                            status_is_error = true;
-                        }
-                    }
-                }
-            }
-
-            render_profile_entry_screen(*renderer, title_font, menu_font, profile_name, status_message, status_is_error);
-            SDL_Delay(16);
-        }
-
-        SDL_StopTextInput();
-
-        if (!accepted)
-            return ft_string();
-
-        return profile_name;
+        if (window != ft_nullptr)
+            SDL_DestroyWindow(window);
     }
 }
 
@@ -539,8 +55,8 @@ int main()
         "Galactic Planet Miner",
         SDL_WINDOWPOS_CENTERED,
         SDL_WINDOWPOS_CENTERED,
-        static_cast<int>(kWindowWidth),
-        static_cast<int>(kWindowHeight),
+        static_cast<int>(app_constants::kWindowWidth),
+        static_cast<int>(app_constants::kWindowHeight),
         SDL_WINDOW_SHOWN);
 
     if (window == ft_nullptr)
@@ -553,7 +69,7 @@ int main()
     SDL_Renderer *renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
     if (renderer == ft_nullptr)
     {
-        SDL_DestroyWindow(window);
+        destroy_window(window);
         TTF_Quit();
         SDL_Quit();
         return 1;
@@ -564,17 +80,42 @@ int main()
     TTF_Font *title_font = resolve_font(48);
     TTF_Font *menu_font = resolve_font(28);
 
-    ft_string active_profile_name = run_profile_entry_flow(window, renderer, title_font, menu_font);
+    bool quit_requested = false;
+    ft_vector<ft_string> available_profiles;
+    player_profile_list(available_profiles);
+
+    ft_string active_profile_name;
+    if (available_profiles.empty())
+    {
+        ft_string created_profile = run_profile_entry_flow(window, renderer, title_font, menu_font, &available_profiles,
+            quit_requested);
+        if (quit_requested || created_profile.empty())
+        {
+            destroy_renderer(renderer);
+            destroy_window(window);
+            TTF_Quit();
+            SDL_Quit();
+            return 0;
+        }
+
+        active_profile_name = created_profile;
+        player_profile_list(available_profiles);
+    }
+    else
+    {
+        active_profile_name = available_profiles[0];
+    }
+
     if (active_profile_name.empty())
     {
-        if (renderer != ft_nullptr)
-            SDL_DestroyRenderer(renderer);
-        if (window != ft_nullptr)
-            SDL_DestroyWindow(window);
+        destroy_renderer(renderer);
+        destroy_window(window);
         TTF_Quit();
         SDL_Quit();
         return 0;
     }
+
+    apply_profile_preferences(window, active_profile_name);
 
     ft_ui_menu menu;
     menu.set_items(build_main_menu_items());
@@ -643,35 +184,68 @@ int main()
         menu.handle_mouse_input(mouse_state);
         menu.handle_keyboard_input(keyboard_state);
 
+        auto process_menu_activation = [&](const ft_menu_item &item) {
+            if (item.identifier == "exit")
+            {
+                running = false;
+                return;
+            }
+
+            if (item.identifier == "swap_profile")
+            {
+                bool management_quit = false;
+                ft_string selected_profile = run_profile_management_flow(window, renderer, title_font, menu_font, active_profile_name,
+                    management_quit);
+                if (management_quit)
+                {
+                    running = false;
+                    return;
+                }
+
+                if (!selected_profile.empty() && selected_profile != active_profile_name)
+                {
+                    active_profile_name = selected_profile;
+                    apply_profile_preferences(window, active_profile_name);
+                }
+
+                player_profile_list(available_profiles);
+            }
+        };
+
         if (mouse_state.left_released)
         {
             const int index = menu.get_hovered_index();
             const ft_menu_item *hovered_item = menu_item_from_index(menu, index);
             if (hovered_item != ft_nullptr)
-                handle_menu_activation(*hovered_item, running);
+            {
+                process_menu_activation(*hovered_item);
+                if (!running)
+                    break;
+            }
         }
 
         if (activate_requested)
         {
             const ft_menu_item *selected_item = menu.get_selected_item();
             if (selected_item != ft_nullptr)
-                handle_menu_activation(*selected_item, running);
+            {
+                process_menu_activation(*selected_item);
+                if (!running)
+                    break;
+            }
         }
 
         int window_width = 0;
         int window_height = 0;
         SDL_GetWindowSize(window, &window_width, &window_height);
-        render_menu(*renderer, menu, title_font, menu_font, window_width, window_height, active_profile_name);
+        render_main_menu(*renderer, menu, title_font, menu_font, window_width, window_height, active_profile_name);
     }
 
-    if (renderer != ft_nullptr)
-        SDL_DestroyRenderer(renderer);
-
-    if (window != ft_nullptr)
-        SDL_DestroyWindow(window);
-
+    destroy_renderer(renderer);
+    destroy_window(window);
     TTF_Quit();
     SDL_Quit();
 
     return 0;
 }
+

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1,0 +1,113 @@
+#include "main_menu_system.hpp"
+
+ft_vector<ft_menu_item> build_main_menu_items()
+{
+    const ft_rect base_rect(460, 220, 360, 56);
+    const int      spacing = 22;
+
+    const char *identifiers[] = {"new_game", "load", "settings", "swap_profile", "exit"};
+    const char *labels[] = {"New Game", "Load", "Settings", "Swap Profile", "Exit"};
+
+    ft_vector<ft_menu_item> items;
+    items.reserve(5U);
+
+    for (int index = 0; index < 5; ++index)
+    {
+        ft_rect item_rect = base_rect;
+        item_rect.top += index * (base_rect.height + spacing);
+        items.push_back(ft_menu_item(
+            ft_string(identifiers[index]),
+            ft_string(labels[index]),
+            item_rect));
+    }
+
+    return items;
+}
+
+void render_main_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *title_font, TTF_Font *menu_font,
+    int window_width, int window_height, const ft_string &active_profile_name)
+{
+    SDL_SetRenderDrawColor(&renderer, 12, 16, 28, 255);
+    SDL_RenderClear(&renderer);
+
+    int output_width = window_width;
+    int output_height = window_height;
+    SDL_GetRendererOutputSize(&renderer, &output_width, &output_height);
+
+    if (title_font != ft_nullptr)
+    {
+        SDL_Color title_color = {220, 220, 245, 255};
+        SDL_Rect  title_rect;
+        SDL_Texture *title_texture = create_text_texture(renderer, *title_font, ft_string("Galactic Planet Miner"), title_color,
+            title_rect);
+        if (title_texture != ft_nullptr)
+        {
+            title_rect.x = output_width / 2 - title_rect.w / 2;
+            title_rect.y = 96;
+            SDL_RenderCopy(&renderer, title_texture, ft_nullptr, &title_rect);
+            SDL_DestroyTexture(title_texture);
+        }
+    }
+
+    if (menu_font != ft_nullptr && !active_profile_name.empty())
+    {
+        ft_string profile_label("Profile: ");
+        profile_label.append(active_profile_name);
+
+        SDL_Color profile_color = {200, 210, 230, 255};
+        SDL_Rect  profile_rect;
+        SDL_Texture *profile_texture = create_text_texture(renderer, *menu_font, profile_label, profile_color, profile_rect);
+        if (profile_texture != ft_nullptr)
+        {
+            profile_rect.x = output_width / 2 - profile_rect.w / 2;
+            profile_rect.y = 164;
+            SDL_RenderCopy(&renderer, profile_texture, ft_nullptr, &profile_rect);
+            SDL_DestroyTexture(profile_texture);
+        }
+    }
+
+    const ft_vector<ft_menu_item> &items = menu.get_items();
+    const int hovered_index = menu.get_hovered_index();
+    const int selected_index = menu.get_selected_index();
+
+    for (size_t index = 0; index < items.size(); ++index)
+    {
+        const ft_menu_item &item = items[index];
+
+        const bool is_hovered = static_cast<int>(index) == hovered_index;
+        const bool is_selected = static_cast<int>(index) == selected_index;
+
+        const Uint8 r = is_hovered ? 56 : (is_selected ? 40 : 28);
+        const Uint8 g = is_hovered ? 84 : (is_selected ? 64 : 36);
+        const Uint8 b = is_hovered ? 140 : (is_selected ? 112 : 60);
+
+        SDL_Rect button_rect;
+        button_rect.x = item.bounds.left;
+        button_rect.y = item.bounds.top;
+        button_rect.w = item.bounds.width;
+        button_rect.h = item.bounds.height;
+
+        SDL_SetRenderDrawColor(&renderer, r, g, b, 255);
+        SDL_RenderFillRect(&renderer, &button_rect);
+
+        SDL_SetRenderDrawColor(&renderer, 90, 110, 160, 255);
+        SDL_RenderDrawRect(&renderer, &button_rect);
+
+        if (menu_font != ft_nullptr)
+        {
+            SDL_Color text_color = {255, 255, 255, 255};
+            SDL_Rect  text_rect;
+            SDL_Texture *text_texture = create_text_texture(renderer, *menu_font, item.label, text_color, text_rect);
+            if (text_texture != ft_nullptr)
+            {
+                text_rect.x = item.bounds.left + (item.bounds.width - text_rect.w) / 2;
+                text_rect.y = item.bounds.top + (item.bounds.height - text_rect.h) / 2;
+                SDL_RenderCopy(&renderer, text_texture, ft_nullptr, &text_rect);
+                SDL_DestroyTexture(text_texture);
+            }
+        }
+    }
+
+    SDL_RenderPresent(&renderer);
+}
+

--- a/src/main_menu_system.hpp
+++ b/src/main_menu_system.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "../libft/Libft/libft.hpp"
+#include "ui_menu.hpp"
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+
+// Font utilities
+TTF_Font *resolve_font(int point_size);
+SDL_Texture *create_text_texture(SDL_Renderer &renderer, TTF_Font &font, const ft_string &text,
+    const SDL_Color &color, SDL_Rect &out_rect);
+
+// Main menu rendering
+ft_vector<ft_menu_item> build_main_menu_items();
+void render_main_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *title_font, TTF_Font *menu_font,
+    int window_width, int window_height, const ft_string &active_profile_name);
+
+// Profile creation and selection flows
+ft_string run_profile_entry_flow(SDL_Window *window, SDL_Renderer *renderer, TTF_Font *title_font, TTF_Font *menu_font,
+    const ft_vector<ft_string> *existing_profiles, bool &out_quit_requested);
+ft_string run_profile_management_flow(SDL_Window *window, SDL_Renderer *renderer, TTF_Font *title_font, TTF_Font *menu_font,
+    const ft_string &current_profile, bool &out_quit_requested);
+
+// Profile window preference helpers
+bool save_profile_preferences(SDL_Window *window, const ft_string &profile_name) noexcept;
+void apply_profile_preferences(SDL_Window *window, const ft_string &profile_name) noexcept;

--- a/src/player_profile.cpp
+++ b/src/player_profile.cpp
@@ -4,14 +4,24 @@
 #include "../libft/Libft/libft.hpp"
 #include "../libft/JSon/document.hpp"
 #include "../libft/File/open_dir.hpp"
+#include "../libft/File/file_utils.hpp"
+#include "../libft/Template/algorithm.hpp"
 
 #include <sys/stat.h>
+#ifdef _WIN32
+#    include <direct.h>
+#    define ft_rmdir _rmdir
+#else
+#    include <unistd.h>
+#    define ft_rmdir rmdir
+#endif
 
 namespace
 {
     const char *kProfileDirectory = "profiles";
     const char *kProfileGroupName = "profile";
     const char *kProfileExtension = ".prof";
+    const char *kProfileSaveDirectory = "saves";
 
     bool ensure_profile_directory_exists() noexcept
     {
@@ -23,6 +33,160 @@ namespace
         if (file_create_directory(kProfileDirectory, 0755) != 0)
             return false;
         return true;
+    }
+
+    ft_string sanitize_commander_name(const ft_string &commander_name) noexcept
+    {
+        const char *raw = commander_name.c_str();
+        if (raw == ft_nullptr)
+            return ft_string("Commander");
+
+        ft_string sanitized;
+        for (size_t index = 0; raw[index] != '\0'; ++index)
+        {
+            const char character = raw[index];
+            const bool is_digit = (character >= '0' && character <= '9');
+            const bool is_upper = (character >= 'A' && character <= 'Z');
+            const bool is_lower = (character >= 'a' && character <= 'z');
+            const bool is_allowed_symbol = (character == '-' || character == '_' || character == ' ');
+            const bool is_forbidden = (character == '/' || character == '\\' || character == ':' || character == '*' ||
+                                       character == '?' || character == '"' || character == '<' || character == '>' ||
+                                       character == '|');
+
+            if ((is_digit || is_upper || is_lower || is_allowed_symbol) && !is_forbidden)
+                sanitized.append(character);
+            else
+                sanitized.append('_');
+        }
+
+        if (sanitized.empty())
+            sanitized = ft_string("Commander");
+        return sanitized;
+    }
+
+    ft_string resolve_commander_directory(const ft_string &commander_name) noexcept
+    {
+        ft_string sanitized = sanitize_commander_name(commander_name);
+        if (sanitized.empty())
+            return ft_string();
+
+        ft_string path(kProfileDirectory);
+        path.append("/");
+        path.append(sanitized);
+        return path;
+    }
+
+    bool ensure_directory_exists(const ft_string &path) noexcept
+    {
+        if (path.empty())
+            return false;
+
+        int exists_result = file_dir_exists(path.c_str());
+        if (exists_result == 0)
+            return true;
+        if (exists_result < 0)
+            return false;
+        if (file_create_directory(path.c_str(), 0755) != 0)
+            return false;
+        return true;
+    }
+
+    bool ensure_profile_save_directory_exists(const ft_string &commander_name) noexcept
+    {
+        if (!ensure_profile_directory_exists())
+            return false;
+
+        ft_string commander_directory = resolve_commander_directory(commander_name);
+        if (commander_directory.empty())
+            return false;
+        if (!ensure_directory_exists(commander_directory))
+            return false;
+
+        ft_string save_directory = commander_directory;
+        save_directory.append("/");
+        save_directory.append(kProfileSaveDirectory);
+        if (!ensure_directory_exists(save_directory))
+            return false;
+        return true;
+    }
+
+    bool remove_directory_recursive(const ft_string &path) noexcept
+    {
+        if (path.empty())
+            return false;
+
+        int exists_result = file_dir_exists(path.c_str());
+        if (exists_result < 0)
+            return false;
+        if (exists_result == 0)
+            return true;
+
+        file_dir *directory_stream = file_opendir(path.c_str());
+        if (directory_stream == ft_nullptr)
+            return false;
+
+        file_dirent *entry = ft_nullptr;
+        while ((entry = file_readdir(directory_stream)) != ft_nullptr)
+        {
+            if (entry->d_name[0] == '\0')
+                continue;
+            if (entry->d_name[0] == '.')
+            {
+                if (entry->d_name[1] == '\0')
+                    continue;
+                if (entry->d_name[1] == '.' && entry->d_name[2] == '\0')
+                    continue;
+            }
+
+            ft_string child_path(path);
+            child_path.append("/");
+            child_path.append(entry->d_name);
+
+            struct stat child_info;
+            if (stat(child_path.c_str(), &child_info) == 0 && S_ISDIR(child_info.st_mode))
+            {
+                if (!remove_directory_recursive(child_path))
+                {
+                    file_closedir(directory_stream);
+                    return false;
+                }
+            }
+            else
+            {
+                if (file_delete(child_path.c_str()) != 0)
+                {
+                    file_closedir(directory_stream);
+                    return false;
+                }
+            }
+        }
+
+        file_closedir(directory_stream);
+        if (ft_rmdir(path.c_str()) != 0)
+            return false;
+        return true;
+    }
+
+    bool read_profile_name_from_file(const ft_string &path, ft_string &out_name) noexcept
+    {
+        out_name.clear();
+        if (path.empty())
+            return false;
+
+        json_document document;
+        if (document.read_from_file(path.c_str()) != 0)
+            return false;
+
+        json_group *group = document.find_group(kProfileGroupName);
+        if (group == ft_nullptr)
+            return false;
+
+        json_item *name_item = document.find_item(group, "commander_name");
+        if (name_item == ft_nullptr || name_item->value == ft_nullptr)
+            return false;
+
+        out_name = ft_string(name_item->value);
+        return !out_name.empty();
     }
 
     bool add_string(json_document &document, json_group *group, const char *key, const ft_string &value) noexcept
@@ -60,35 +224,6 @@ namespace
         out_value = static_cast<unsigned int>(parsed);
         return true;
     }
-
-    ft_string sanitize_commander_name(const ft_string &commander_name) noexcept
-    {
-        const char *raw = commander_name.c_str();
-        if (raw == ft_nullptr)
-            return ft_string("Commander");
-
-        ft_string sanitized;
-        for (size_t index = 0; raw[index] != '\0'; ++index)
-        {
-            const char character = raw[index];
-            const bool is_digit = (character >= '0' && character <= '9');
-            const bool is_upper = (character >= 'A' && character <= 'Z');
-            const bool is_lower = (character >= 'a' && character <= 'z');
-            const bool is_allowed_symbol = (character == '-' || character == '_' || character == ' ');
-            const bool is_forbidden = (character == '/' || character == '\\' || character == ':' || character == '*' ||
-                                       character == '?' || character == '"' || character == '<' || character == '>' ||
-                                       character == '|');
-
-            if ((is_digit || is_upper || is_lower || is_allowed_symbol) && !is_forbidden)
-                sanitized.append(character);
-            else
-                sanitized.append('_');
-        }
-
-        if (sanitized.empty())
-            sanitized = ft_string("Commander");
-        return sanitized;
-    }
 }
 
 ft_string player_profile_resolve_path(const ft_string &commander_name) noexcept
@@ -109,6 +244,8 @@ bool player_profile_save(const PlayerProfilePreferences &preferences) noexcept
     if (preferences.commander_name.empty())
         return false;
     if (!ensure_profile_directory_exists())
+        return false;
+    if (!ensure_profile_save_directory_exists(preferences.commander_name))
         return false;
 
     ft_string path = player_profile_resolve_path(preferences.commander_name);
@@ -169,4 +306,109 @@ bool player_profile_load_or_create(PlayerProfilePreferences &out_preferences, co
     out_preferences.window_width = parsed_width;
     out_preferences.window_height = parsed_height;
     return true;
+}
+
+ft_string player_profile_resolve_save_directory(const ft_string &commander_name) noexcept
+{
+    ft_string commander_directory = resolve_commander_directory(commander_name);
+    if (commander_directory.empty())
+        return ft_string();
+
+    commander_directory.append("/");
+    commander_directory.append(kProfileSaveDirectory);
+    return commander_directory;
+}
+
+bool player_profile_list(ft_vector<ft_string> &out_profiles) noexcept
+{
+    out_profiles.clear();
+    if (!ensure_profile_directory_exists())
+        return false;
+
+    file_dir *directory_stream = file_opendir(kProfileDirectory);
+    if (directory_stream == ft_nullptr)
+        return false;
+
+    const size_t extension_length = ft_strlen(kProfileExtension);
+    file_dirent *entry = ft_nullptr;
+    while ((entry = file_readdir(directory_stream)) != ft_nullptr)
+    {
+        if (entry->d_name[0] == '\0')
+            continue;
+        if (entry->d_name[0] == '.')
+        {
+            if (entry->d_name[1] == '\0')
+                continue;
+            if (entry->d_name[1] == '.' && entry->d_name[2] == '\0')
+                continue;
+        }
+
+        const char *name = entry->d_name;
+        size_t name_length = ft_strlen(name);
+        if (name_length <= extension_length)
+            continue;
+        bool matches_extension = true;
+        for (size_t index = 0; index < extension_length; ++index)
+        {
+            char expected = kProfileExtension[index];
+            char actual = name[name_length - extension_length + index];
+            if (expected != actual)
+            {
+                matches_extension = false;
+                break;
+            }
+        }
+        if (!matches_extension)
+            continue;
+
+        ft_string profile_path(kProfileDirectory);
+        profile_path.append("/");
+        profile_path.append(name);
+
+        ft_string commander_name;
+        if (!read_profile_name_from_file(profile_path, commander_name))
+            continue;
+
+        out_profiles.push_back(commander_name);
+    }
+
+    file_closedir(directory_stream);
+    if (out_profiles.size() > 1U)
+        ft_sort(out_profiles.begin(), out_profiles.end());
+    return true;
+}
+
+bool player_profile_delete(const ft_string &commander_name) noexcept
+{
+    if (commander_name.empty())
+        return false;
+
+    if (!ensure_profile_directory_exists())
+        return false;
+
+    bool success = true;
+
+    ft_string path = player_profile_resolve_path(commander_name);
+    if (!path.empty())
+    {
+        if (file_delete(path.c_str()) != 0)
+        {
+            struct stat path_info;
+            if (stat(path.c_str(), &path_info) == 0)
+                success = false;
+        }
+    }
+
+    ft_string commander_directory = resolve_commander_directory(commander_name);
+    if (!commander_directory.empty())
+    {
+        if (!remove_directory_recursive(commander_directory))
+        {
+            int exists_result = file_dir_exists(commander_directory.c_str());
+            if (exists_result > 0)
+                success = false;
+        }
+    }
+
+    return success;
 }

--- a/src/player_profile.hpp
+++ b/src/player_profile.hpp
@@ -2,6 +2,7 @@
 #define PLAYER_PROFILE_HPP
 
 #include "../libft/CPP_class/class_string_class.hpp"
+#include "../libft/Template/vector.hpp"
 
 struct PlayerProfilePreferences
 {
@@ -15,5 +16,8 @@ struct PlayerProfilePreferences
 bool player_profile_load_or_create(PlayerProfilePreferences &out_preferences, const ft_string &commander_name) noexcept;
 bool player_profile_save(const PlayerProfilePreferences &preferences) noexcept;
 ft_string player_profile_resolve_path(const ft_string &commander_name) noexcept;
+bool player_profile_list(ft_vector<ft_string> &out_profiles) noexcept;
+bool player_profile_delete(const ft_string &commander_name) noexcept;
+ft_string player_profile_resolve_save_directory(const ft_string &commander_name) noexcept;
 
 #endif

--- a/src/profile_entry_flow.cpp
+++ b/src/profile_entry_flow.cpp
@@ -1,0 +1,310 @@
+#include "main_menu_system.hpp"
+
+#include "app_constants.hpp"
+
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+namespace
+{
+    constexpr unsigned int kMaxProfileNameLength = 24U;
+
+    enum e_profile_append_result
+    {
+        PROFILE_APPEND_REJECTED = 0,
+        PROFILE_APPEND_ACCEPTED = 1,
+        PROFILE_APPEND_MAX_LENGTH = 2
+    };
+
+    bool is_profile_character_allowed(char character) noexcept
+    {
+        const bool is_lower = (character >= 'a' && character <= 'z');
+        const bool is_upper = (character >= 'A' && character <= 'Z');
+        const bool is_digit = (character >= '0' && character <= '9');
+        return is_lower || is_upper || is_digit;
+    }
+
+    e_profile_append_result append_profile_character(ft_string &profile_name, char character) noexcept
+    {
+        if (!is_profile_character_allowed(character))
+            return PROFILE_APPEND_REJECTED;
+
+        if (profile_name.size() >= static_cast<size_t>(kMaxProfileNameLength))
+            return PROFILE_APPEND_MAX_LENGTH;
+
+        profile_name.append(character);
+        return PROFILE_APPEND_ACCEPTED;
+    }
+
+    void remove_last_profile_character(ft_string &profile_name) noexcept
+    {
+        const size_t current_size = profile_name.size();
+        if (current_size == 0U)
+            return;
+        profile_name.erase(current_size - 1U, 1U);
+    }
+
+    bool profile_name_is_valid(const ft_string &profile_name) noexcept
+    {
+        return !profile_name.empty();
+    }
+
+    bool profile_name_exists(const ft_vector<ft_string> &profiles, const ft_string &candidate) noexcept
+    {
+        for (size_t index = 0; index < profiles.size(); ++index)
+        {
+            if (profiles[index] == candidate)
+                return true;
+        }
+        return false;
+    }
+
+    void render_profile_entry_screen(SDL_Renderer &renderer, TTF_Font *title_font, TTF_Font *menu_font,
+        const ft_string &profile_name, const ft_string &status_message, bool status_is_error)
+    {
+        SDL_SetRenderDrawColor(&renderer, 12, 16, 28, 255);
+        SDL_RenderClear(&renderer);
+
+        int output_width = static_cast<int>(app_constants::kWindowWidth);
+        int output_height = static_cast<int>(app_constants::kWindowHeight);
+        SDL_GetRendererOutputSize(&renderer, &output_width, &output_height);
+
+        if (title_font != ft_nullptr)
+        {
+            SDL_Color title_color = {220, 220, 245, 255};
+            SDL_Rect  title_rect;
+            SDL_Texture *title_texture = create_text_texture(renderer, *title_font, ft_string("Commander Profile"), title_color,
+                title_rect);
+            if (title_texture != ft_nullptr)
+            {
+                title_rect.x = output_width / 2 - title_rect.w / 2;
+                title_rect.y = 96;
+                SDL_RenderCopy(&renderer, title_texture, ft_nullptr, &title_rect);
+                SDL_DestroyTexture(title_texture);
+            }
+        }
+
+        SDL_Rect input_rect;
+        input_rect.w = 520;
+        input_rect.h = 68;
+        input_rect.x = output_width / 2 - input_rect.w / 2;
+        input_rect.y = output_height / 2 - input_rect.h / 2;
+
+        SDL_SetRenderDrawColor(&renderer, 18, 24, 44, 240);
+        SDL_RenderFillRect(&renderer, &input_rect);
+        SDL_SetRenderDrawColor(&renderer, 90, 110, 160, 255);
+        SDL_RenderDrawRect(&renderer, &input_rect);
+
+        int caret_x = input_rect.x + 18;
+
+        if (menu_font != ft_nullptr)
+        {
+            bool is_placeholder = profile_name.empty();
+            ft_string display_text;
+            if (is_placeholder)
+                display_text = ft_string("Enter profile name");
+            else
+                display_text = profile_name;
+
+            SDL_Color text_color;
+            if (is_placeholder)
+            {
+                text_color.r = 140;
+                text_color.g = 150;
+                text_color.b = 170;
+                text_color.a = 255;
+            }
+            else
+            {
+                text_color.r = 230;
+                text_color.g = 235;
+                text_color.b = 245;
+                text_color.a = 255;
+            }
+
+            SDL_Rect text_rect;
+            SDL_Texture *text_texture = create_text_texture(renderer, *menu_font, display_text, text_color, text_rect);
+            if (text_texture != ft_nullptr)
+            {
+                text_rect.x = input_rect.x + 18;
+                text_rect.y = input_rect.y + (input_rect.h - text_rect.h) / 2;
+                SDL_RenderCopy(&renderer, text_texture, ft_nullptr, &text_rect);
+                caret_x = text_rect.x + text_rect.w + 4;
+                SDL_DestroyTexture(text_texture);
+            }
+
+            if (!is_placeholder)
+            {
+                SDL_Rect caret_rect;
+                caret_rect.x = caret_x;
+                caret_rect.y = input_rect.y + 8;
+                caret_rect.w = 2;
+                caret_rect.h = input_rect.h - 16;
+                SDL_SetRenderDrawColor(&renderer, 210, 220, 250, 255);
+                SDL_RenderFillRect(&renderer, &caret_rect);
+            }
+
+            ft_string instructions("Letters and numbers only. Press Enter to confirm.");
+            SDL_Color instruction_color = {170, 180, 210, 255};
+            SDL_Rect  instruction_rect;
+            SDL_Texture *instruction_texture = create_text_texture(renderer, *menu_font, instructions, instruction_color,
+                instruction_rect);
+            if (instruction_texture != ft_nullptr)
+            {
+                instruction_rect.x = output_width / 2 - instruction_rect.w / 2;
+                instruction_rect.y = input_rect.y + input_rect.h + 36;
+                SDL_RenderCopy(&renderer, instruction_texture, ft_nullptr, &instruction_rect);
+                SDL_DestroyTexture(instruction_texture);
+            }
+
+            if (!status_message.empty())
+            {
+                SDL_Color status_color;
+                if (status_is_error)
+                {
+                    status_color.r = 220;
+                    status_color.g = 90;
+                    status_color.b = 90;
+                    status_color.a = 255;
+                }
+                else
+                {
+                    status_color.r = 180;
+                    status_color.g = 200;
+                    status_color.b = 220;
+                    status_color.a = 255;
+                }
+
+                SDL_Rect status_rect;
+                SDL_Texture *status_texture = create_text_texture(renderer, *menu_font, status_message, status_color, status_rect);
+                if (status_texture != ft_nullptr)
+                {
+                    status_rect.x = output_width / 2 - status_rect.w / 2;
+                    status_rect.y = input_rect.y + input_rect.h + 80;
+                    SDL_RenderCopy(&renderer, status_texture, ft_nullptr, &status_rect);
+                    SDL_DestroyTexture(status_texture);
+                }
+            }
+        }
+
+        SDL_RenderPresent(&renderer);
+    }
+}
+
+ft_string run_profile_entry_flow(SDL_Window *window, SDL_Renderer *renderer, TTF_Font *title_font, TTF_Font *menu_font,
+    const ft_vector<ft_string> *existing_profiles, bool &out_quit_requested)
+{
+    if (window == ft_nullptr || renderer == ft_nullptr)
+        return ft_string();
+
+    ft_string profile_name;
+    ft_string status_message;
+    bool status_is_error = false;
+    bool running = true;
+    bool accepted = false;
+    out_quit_requested = false;
+
+    SDL_StartTextInput();
+
+    while (running && !accepted)
+    {
+        SDL_Event event;
+        while (SDL_PollEvent(&event) == 1)
+        {
+            if (event.type == SDL_QUIT)
+            {
+                running = false;
+                out_quit_requested = true;
+            }
+            else if (event.type == SDL_KEYDOWN)
+            {
+                if (event.key.keysym.sym == SDLK_ESCAPE)
+                {
+                    running = false;
+                }
+                else if (event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER)
+                {
+                    if (!profile_name_is_valid(profile_name))
+                    {
+                        status_message = ft_string("Please enter a profile name.");
+                        status_is_error = true;
+                    }
+                    else if (existing_profiles != ft_nullptr && profile_name_exists(*existing_profiles, profile_name))
+                    {
+                        status_message = ft_string("A profile with that name already exists.");
+                        status_is_error = true;
+                    }
+                    else if (save_profile_preferences(window, profile_name))
+                    {
+                        accepted = true;
+                    }
+                    else
+                    {
+                        status_message = ft_string("Unable to save profile. Check write permissions.");
+                        status_is_error = true;
+                    }
+                }
+                else if (event.key.keysym.sym == SDLK_BACKSPACE)
+                {
+                    remove_last_profile_character(profile_name);
+                    status_message.clear();
+                    status_is_error = false;
+                }
+            }
+            else if (event.type == SDL_TEXTINPUT)
+            {
+                const char *text = event.text.text;
+                if (text != ft_nullptr)
+                {
+                    bool appended_character = false;
+                    bool rejected_for_length = false;
+                    bool rejected_for_invalid = false;
+
+                    for (int index = 0; text[index] != '\0'; ++index)
+                    {
+                        const char character = text[index];
+                        const e_profile_append_result result = append_profile_character(profile_name, character);
+                        if (result == PROFILE_APPEND_ACCEPTED)
+                        {
+                            appended_character = true;
+                        }
+                        else if (result == PROFILE_APPEND_MAX_LENGTH)
+                        {
+                            rejected_for_length = true;
+                        }
+                        else
+                        {
+                            rejected_for_invalid = true;
+                        }
+                    }
+
+                    if (appended_character)
+                    {
+                        status_message.clear();
+                        status_is_error = false;
+                    }
+                    else if (rejected_for_length)
+                    {
+                        status_message = ft_string("Profile names are limited to 24 characters.");
+                        status_is_error = true;
+                    }
+                    else if (rejected_for_invalid)
+                    {
+                        status_message = ft_string("Use letters and numbers only.");
+                        status_is_error = true;
+                    }
+                }
+            }
+        }
+
+        render_profile_entry_screen(*renderer, title_font, menu_font, profile_name, status_message, status_is_error);
+        SDL_Delay(16);
+    }
+
+    SDL_StopTextInput();
+
+    if (!accepted)
+        return ft_string();
+
+    return profile_name;
+}
+

--- a/src/profile_management_flow.cpp
+++ b/src/profile_management_flow.cpp
@@ -1,0 +1,400 @@
+#include "main_menu_system.hpp"
+
+#include "app_constants.hpp"
+#include "player_profile.hpp"
+#include "ui_input.hpp"
+
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+namespace
+{
+    size_t find_profile_index(const ft_vector<ft_string> &profiles, const ft_string &profile_name) noexcept
+    {
+        for (size_t index = 0; index < profiles.size(); ++index)
+        {
+            if (profiles[index] == profile_name)
+                return index;
+        }
+        return profiles.size();
+    }
+
+    void rebuild_profile_menu(ft_ui_menu &menu, const ft_vector<ft_string> &profiles, const ft_string &current_profile,
+        size_t preferred_profile_index, bool select_create_item)
+    {
+        const ft_rect base_rect(460, 220, 360, 56);
+        const int      spacing = 18;
+
+        ft_vector<ft_menu_item> items;
+        const size_t             profile_count = profiles.size();
+        items.reserve(profile_count + 1U);
+
+        for (size_t index = 0; index < profile_count; ++index)
+        {
+            ft_rect item_rect = base_rect;
+            item_rect.top += static_cast<int>(index) * (base_rect.height + spacing);
+
+            ft_string label = profiles[index];
+            if (profiles[index] == current_profile)
+                label.append(" (Current)");
+
+            ft_string identifier("profile:");
+            identifier.append(ft_to_string(static_cast<int>(index)));
+
+            items.push_back(ft_menu_item(identifier, label, item_rect));
+        }
+
+        ft_rect create_rect = base_rect;
+        create_rect.top += static_cast<int>(profile_count) * (base_rect.height + spacing);
+        items.push_back(ft_menu_item(ft_string("profile:create"), ft_string("Create New Profile"), create_rect));
+
+        menu.set_items(items);
+
+        if (select_create_item)
+        {
+            menu.set_selected_index(static_cast<int>(profile_count));
+        }
+        else if (preferred_profile_index < profile_count)
+        {
+            menu.set_selected_index(static_cast<int>(preferred_profile_index));
+        }
+        else if (profile_count > 0U)
+        {
+            menu.set_selected_index(0);
+        }
+        else
+        {
+            menu.set_selected_index(static_cast<int>(profile_count));
+        }
+    }
+
+    void render_profile_management_screen(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *title_font,
+        TTF_Font *menu_font, const ft_string &status_message, bool status_is_error)
+    {
+        SDL_SetRenderDrawColor(&renderer, 12, 16, 28, 255);
+        SDL_RenderClear(&renderer);
+
+        int output_width = static_cast<int>(app_constants::kWindowWidth);
+        int output_height = static_cast<int>(app_constants::kWindowHeight);
+        SDL_GetRendererOutputSize(&renderer, &output_width, &output_height);
+
+        if (title_font != ft_nullptr)
+        {
+            SDL_Color title_color = {220, 220, 245, 255};
+            SDL_Rect  title_rect;
+            SDL_Texture *title_texture = create_text_texture(renderer, *title_font, ft_string("Commander Profiles"), title_color,
+                title_rect);
+            if (title_texture != ft_nullptr)
+            {
+                title_rect.x = output_width / 2 - title_rect.w / 2;
+                title_rect.y = 96;
+                SDL_RenderCopy(&renderer, title_texture, ft_nullptr, &title_rect);
+                SDL_DestroyTexture(title_texture);
+            }
+        }
+
+        if (menu_font != ft_nullptr)
+        {
+            SDL_Color info_color = {170, 180, 210, 255};
+            SDL_Rect  info_rect;
+            ft_string info_text("Enter or click to activate a profile. Delete removes the selected profile. Esc cancels.");
+            SDL_Texture *info_texture = create_text_texture(renderer, *menu_font, info_text, info_color, info_rect);
+            if (info_texture != ft_nullptr)
+            {
+                info_rect.x = output_width / 2 - info_rect.w / 2;
+                info_rect.y = 164;
+                SDL_RenderCopy(&renderer, info_texture, ft_nullptr, &info_rect);
+                SDL_DestroyTexture(info_texture);
+            }
+        }
+
+        const ft_vector<ft_menu_item> &items = menu.get_items();
+        const int hovered_index = menu.get_hovered_index();
+        const int selected_index = menu.get_selected_index();
+
+        for (size_t index = 0; index < items.size(); ++index)
+        {
+            const ft_menu_item &item = items[index];
+
+            const bool is_hovered = static_cast<int>(index) == hovered_index;
+            const bool is_selected = static_cast<int>(index) == selected_index;
+
+            const Uint8 r = is_hovered ? 56 : (is_selected ? 40 : 28);
+            const Uint8 g = is_hovered ? 84 : (is_selected ? 64 : 36);
+            const Uint8 b = is_hovered ? 140 : (is_selected ? 112 : 60);
+
+            SDL_Rect button_rect;
+            button_rect.x = item.bounds.left;
+            button_rect.y = item.bounds.top;
+            button_rect.w = item.bounds.width;
+            button_rect.h = item.bounds.height;
+
+            SDL_SetRenderDrawColor(&renderer, r, g, b, 255);
+            SDL_RenderFillRect(&renderer, &button_rect);
+
+            SDL_SetRenderDrawColor(&renderer, 90, 110, 160, 255);
+            SDL_RenderDrawRect(&renderer, &button_rect);
+
+            if (menu_font != ft_nullptr)
+            {
+                SDL_Color text_color = {255, 255, 255, 255};
+                SDL_Rect  text_rect;
+                SDL_Texture *text_texture = create_text_texture(renderer, *menu_font, item.label, text_color, text_rect);
+                if (text_texture != ft_nullptr)
+                {
+                    text_rect.x = item.bounds.left + (item.bounds.width - text_rect.w) / 2;
+                    text_rect.y = item.bounds.top + (item.bounds.height - text_rect.h) / 2;
+                    SDL_RenderCopy(&renderer, text_texture, ft_nullptr, &text_rect);
+                    SDL_DestroyTexture(text_texture);
+                }
+            }
+        }
+
+        if (menu_font != ft_nullptr && !status_message.empty())
+        {
+            SDL_Color status_color;
+            if (status_is_error)
+            {
+                status_color.r = 220;
+                status_color.g = 90;
+                status_color.b = 90;
+                status_color.a = 255;
+            }
+            else
+            {
+                status_color.r = 180;
+                status_color.g = 200;
+                status_color.b = 220;
+                status_color.a = 255;
+            }
+
+            SDL_Rect status_rect;
+            SDL_Texture *status_texture = create_text_texture(renderer, *menu_font, status_message, status_color, status_rect);
+            if (status_texture != ft_nullptr)
+            {
+                status_rect.x = output_width / 2 - status_rect.w / 2;
+                status_rect.y = output_height - status_rect.h - 120;
+                SDL_RenderCopy(&renderer, status_texture, ft_nullptr, &status_rect);
+                SDL_DestroyTexture(status_texture);
+            }
+        }
+
+        SDL_RenderPresent(&renderer);
+    }
+}
+
+ft_string run_profile_management_flow(SDL_Window *window, SDL_Renderer *renderer, TTF_Font *title_font, TTF_Font *menu_font,
+    const ft_string &current_profile, bool &out_quit_requested)
+{
+    out_quit_requested = false;
+    if (window == ft_nullptr || renderer == ft_nullptr)
+        return ft_string();
+
+    ft_vector<ft_string> profiles;
+    if (!player_profile_list(profiles))
+        return ft_string();
+
+    if (profiles.empty())
+    {
+        bool creation_quit = false;
+        ft_string created_profile = run_profile_entry_flow(window, renderer, title_font, menu_font, &profiles, creation_quit);
+        if (creation_quit)
+        {
+            out_quit_requested = true;
+            return ft_string();
+        }
+        if (created_profile.empty())
+            return ft_string();
+
+        player_profile_list(profiles);
+    }
+
+    size_t preferred_index = find_profile_index(profiles, current_profile);
+    ft_ui_menu menu;
+    rebuild_profile_menu(menu, profiles, current_profile, preferred_index, false);
+    int last_selected_index = menu.get_selected_index();
+
+    ft_string status_message;
+    bool      status_is_error = false;
+    bool      running = true;
+    int       pending_delete_index = -1;
+    ft_string pending_delete_name;
+
+    while (running)
+    {
+        ft_mouse_state    mouse_state;
+        ft_keyboard_state keyboard_state;
+        bool              activate_requested = false;
+        bool              delete_requested = false;
+
+        SDL_Event event;
+        while (SDL_PollEvent(&event) == 1)
+        {
+            if (event.type == SDL_QUIT)
+            {
+                out_quit_requested = true;
+                running = false;
+            }
+            else if (event.type == SDL_MOUSEMOTION)
+            {
+                mouse_state.moved = true;
+                mouse_state.x = event.motion.x;
+                mouse_state.y = event.motion.y;
+            }
+            else if (event.type == SDL_MOUSEBUTTONDOWN)
+            {
+                if (event.button.button == SDL_BUTTON_LEFT)
+                {
+                    mouse_state.left_pressed = true;
+                    mouse_state.x = event.button.x;
+                    mouse_state.y = event.button.y;
+                }
+            }
+            else if (event.type == SDL_MOUSEBUTTONUP)
+            {
+                if (event.button.button == SDL_BUTTON_LEFT)
+                {
+                    mouse_state.left_released = true;
+                    mouse_state.x = event.button.x;
+                    mouse_state.y = event.button.y;
+                }
+            }
+            else if (event.type == SDL_KEYDOWN)
+            {
+                if (event.key.keysym.sym == SDLK_UP)
+                    keyboard_state.pressed_up = true;
+                else if (event.key.keysym.sym == SDLK_DOWN)
+                    keyboard_state.pressed_down = true;
+                else if (event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_SPACE)
+                    activate_requested = true;
+                else if (event.key.keysym.sym == SDLK_DELETE || event.key.keysym.sym == SDLK_BACKSPACE)
+                    delete_requested = true;
+                else if (event.key.keysym.sym == SDLK_ESCAPE)
+                    running = false;
+            }
+        }
+
+        if (!running)
+            break;
+
+        if (!mouse_state.moved)
+        {
+            int x = 0;
+            int y = 0;
+            SDL_GetMouseState(&x, &y);
+            mouse_state.x = x;
+            mouse_state.y = y;
+        }
+
+        menu.handle_mouse_input(mouse_state);
+        menu.handle_keyboard_input(keyboard_state);
+
+        int current_selected_index = menu.get_selected_index();
+        if (current_selected_index != last_selected_index)
+        {
+            pending_delete_index = -1;
+            pending_delete_name.clear();
+            status_message.clear();
+            status_is_error = false;
+            last_selected_index = current_selected_index;
+        }
+
+        size_t profile_count = profiles.size();
+        int    activation_index = -1;
+        if (mouse_state.left_released)
+            activation_index = menu.get_hovered_index();
+        if (activation_index < 0 && activate_requested)
+            activation_index = menu.get_selected_index();
+
+        if (activation_index >= 0)
+        {
+            if (static_cast<size_t>(activation_index) < profile_count)
+                return profiles[static_cast<size_t>(activation_index)];
+
+            if (static_cast<size_t>(activation_index) == profile_count)
+            {
+                bool creation_quit = false;
+                ft_string new_profile = run_profile_entry_flow(window, renderer, title_font, menu_font, &profiles, creation_quit);
+                if (creation_quit)
+                {
+                    out_quit_requested = true;
+                    return ft_string();
+                }
+                if (!new_profile.empty())
+                {
+                    player_profile_list(profiles);
+                    profile_count = profiles.size();
+                    preferred_index = find_profile_index(profiles, new_profile);
+                    rebuild_profile_menu(menu, profiles, current_profile, preferred_index, false);
+                    last_selected_index = menu.get_selected_index();
+                    status_message = ft_string("Created profile: ");
+                    status_message.append(new_profile);
+                    status_is_error = false;
+                    pending_delete_index = -1;
+                    pending_delete_name.clear();
+                }
+            }
+        }
+
+        if (delete_requested)
+        {
+            int selected_index = menu.get_selected_index();
+            if (selected_index >= 0 && static_cast<size_t>(selected_index) < profile_count)
+            {
+                if (profile_count <= 1U)
+                {
+                    status_message = ft_string("At least one profile must remain.");
+                    status_is_error = true;
+                    pending_delete_index = -1;
+                    pending_delete_name.clear();
+                }
+                else if (pending_delete_index == selected_index)
+                {
+                    ft_string name_to_delete = profiles[static_cast<size_t>(selected_index)];
+                    if (player_profile_delete(name_to_delete))
+                    {
+                        player_profile_list(profiles);
+                        profile_count = profiles.size();
+                        if (profile_count == 0U)
+                        {
+                            status_message = ft_string("No profiles available.");
+                            status_is_error = true;
+                            return ft_string();
+                        }
+
+                        size_t new_preferred_index = static_cast<size_t>(selected_index);
+                        if (new_preferred_index >= profile_count)
+                            new_preferred_index = profile_count - 1U;
+
+                        rebuild_profile_menu(menu, profiles, current_profile, new_preferred_index, false);
+                        last_selected_index = menu.get_selected_index();
+                        status_message = ft_string("Deleted profile: ");
+                        status_message.append(name_to_delete);
+                        status_is_error = false;
+                    }
+                    else
+                    {
+                        status_message = ft_string("Unable to delete profile.");
+                        status_is_error = true;
+                    }
+
+                    pending_delete_index = -1;
+                    pending_delete_name.clear();
+                }
+                else
+                {
+                    pending_delete_index = selected_index;
+                    pending_delete_name = profiles[static_cast<size_t>(selected_index)];
+                    status_message = ft_string("Press Delete again to remove: ");
+                    status_message.append(pending_delete_name);
+                    status_is_error = true;
+                }
+            }
+        }
+
+        render_profile_management_screen(*renderer, menu, title_font, menu_font, status_message, status_is_error);
+        SDL_Delay(16);
+    }
+
+    return ft_string();
+}
+

--- a/src/profile_preferences.cpp
+++ b/src/profile_preferences.cpp
@@ -1,0 +1,42 @@
+#include "main_menu_system.hpp"
+
+#include "app_constants.hpp"
+#include "player_profile.hpp"
+
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+bool save_profile_preferences(SDL_Window *window, const ft_string &profile_name) noexcept
+{
+    if (window == ft_nullptr)
+        return false;
+
+    PlayerProfilePreferences preferences;
+    preferences.commander_name = profile_name;
+
+    int window_width = static_cast<int>(app_constants::kWindowWidth);
+    int window_height = static_cast<int>(app_constants::kWindowHeight);
+    SDL_GetWindowSize(window, &window_width, &window_height);
+
+    if (window_width > 0)
+        preferences.window_width = static_cast<unsigned int>(window_width);
+    if (window_height > 0)
+        preferences.window_height = static_cast<unsigned int>(window_height);
+
+    return player_profile_save(preferences);
+}
+
+void apply_profile_preferences(SDL_Window *window, const ft_string &profile_name) noexcept
+{
+    if (window == ft_nullptr || profile_name.empty())
+        return;
+
+    PlayerProfilePreferences preferences;
+    if (!player_profile_load_or_create(preferences, profile_name))
+        return;
+
+    int window_width = static_cast<int>(preferences.window_width);
+    int window_height = static_cast<int>(preferences.window_height);
+    if (window_width > 0 && window_height > 0)
+        SDL_SetWindowSize(window, window_width, window_height);
+}
+


### PR DESCRIPTION
## Summary
- add a profile management flow that lists existing profiles and supports creating, selecting, or deleting them from the main menu
- create per-profile save directories and clean them up when removing profiles while preserving profile preference loading
- apply stored window preferences whenever the active profile changes
- refactor the main menu and profile flows into dedicated modules and expose their declarations through a single shared header so `main.cpp` can stay a thin orchestrator

## Testing
- make *(fails: SDL2 development libraries (SDL2 and SDL2_ttf) not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da5b7ccdac8331916dc1ee6d83f5bb