### PR TITLE
Add SDL fallbacks for headless build support

### DIFF
--- a/font_util.cpp
+++ b/font_util.cpp
@@ -2,6 +2,8 @@
 
 #include "libft/CPP_class/class_nullptr.hpp"
 
+#if GALACTIC_HAVE_SDL2
+
 namespace
 {
     struct font_cache_entry
@@ -87,4 +89,28 @@ SDL_Texture *create_text_texture(SDL_Renderer &renderer, TTF_Font &font, const f
     SDL_FreeSurface(surface);
     return texture;
 }
+
+#else
+
+TTF_Font *resolve_font(int point_size)
+{
+    (void)point_size;
+    return ft_nullptr;
+}
+
+SDL_Texture *create_text_texture(SDL_Renderer &renderer, TTF_Font &font, const ft_string &text,
+    const SDL_Color &color, SDL_Rect &out_rect)
+{
+    (void)renderer;
+    (void)font;
+    (void)text;
+    (void)color;
+    out_rect.x = 0;
+    out_rect.y = 0;
+    out_rect.w = 0;
+    out_rect.h = 0;
+    return ft_nullptr;
+}
+
+#endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -7,8 +7,12 @@
 #include "libft/CPP_class/class_nullptr.hpp"
 #include "libft/Libft/libft.hpp"
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
+#if GALACTIC_HAVE_SDL2
+#    include <SDL2/SDL.h>
+#    include <SDL2/SDL_ttf.h>
+#endif
+
+#if GALACTIC_HAVE_SDL2
 
 namespace
 {
@@ -248,4 +252,13 @@ int main()
 
     return 0;
 }
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif
 

--- a/main_menu.cpp
+++ b/main_menu.cpp
@@ -27,6 +27,7 @@ ft_vector<ft_menu_item> build_main_menu_items()
 void render_main_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *title_font, TTF_Font *menu_font,
     int window_width, int window_height, const ft_string &active_profile_name)
 {
+#if GALACTIC_HAVE_SDL2
     SDL_SetRenderDrawColor(&renderer, 12, 16, 28, 255);
     SDL_RenderClear(&renderer);
 
@@ -109,5 +110,14 @@ void render_main_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *
     }
 
     SDL_RenderPresent(&renderer);
+#else
+    (void)renderer;
+    (void)menu;
+    (void)title_font;
+    (void)menu_font;
+    (void)window_width;
+    (void)window_height;
+    (void)active_profile_name;
+#endif
 }
 

--- a/main_menu_system.hpp
+++ b/main_menu_system.hpp
@@ -3,8 +3,44 @@
 #include "libft/Libft/libft.hpp"
 #include "ui_menu.hpp"
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
+#if defined(__has_include)
+#  if __has_include(<SDL2/SDL.h>) && __has_include(<SDL2/SDL_ttf.h>)
+#    define GALACTIC_HAVE_SDL2 1
+#  else
+#    define GALACTIC_HAVE_SDL2 0
+#  endif
+#else
+#  define GALACTIC_HAVE_SDL2 0
+#endif
+
+#if GALACTIC_HAVE_SDL2
+#    include <SDL2/SDL.h>
+#    include <SDL2/SDL_ttf.h>
+#else
+struct SDL_Window;
+struct SDL_Renderer;
+struct SDL_Texture;
+struct SDL_Surface;
+
+struct SDL_Color
+{
+    unsigned char r;
+    unsigned char g;
+    unsigned char b;
+    unsigned char a;
+};
+
+struct SDL_Rect
+{
+    int x;
+    int y;
+    int w;
+    int h;
+};
+
+struct _TTF_Font;
+typedef _TTF_Font TTF_Font;
+#endif
 
 // Font utilities
 TTF_Font *resolve_font(int point_size);

--- a/profile_entry_flow.cpp
+++ b/profile_entry_flow.cpp
@@ -6,6 +6,7 @@
 
 namespace
 {
+#if GALACTIC_HAVE_SDL2
     constexpr unsigned int kMaxProfileNameLength = 24U;
 
     enum e_profile_append_result
@@ -188,11 +189,13 @@ namespace
 
         SDL_RenderPresent(&renderer);
     }
+#endif
 }
 
 ft_string run_profile_entry_flow(SDL_Window *window, SDL_Renderer *renderer, TTF_Font *title_font, TTF_Font *menu_font,
     const ft_vector<ft_string> *existing_profiles, bool &out_quit_requested)
 {
+#if GALACTIC_HAVE_SDL2
     if (window == ft_nullptr || renderer == ft_nullptr)
         return ft_string();
 
@@ -306,5 +309,14 @@ ft_string run_profile_entry_flow(SDL_Window *window, SDL_Renderer *renderer, TTF
         return ft_string();
 
     return profile_name;
+#else
+    (void)window;
+    (void)renderer;
+    (void)title_font;
+    (void)menu_font;
+    (void)existing_profiles;
+    out_quit_requested = true;
+    return ft_string();
+#endif
 }
 

--- a/profile_management_flow.cpp
+++ b/profile_management_flow.cpp
@@ -8,6 +8,7 @@
 
 namespace
 {
+#if GALACTIC_HAVE_SDL2
     size_t find_profile_index(const ft_vector<ft_string> &profiles, const ft_string &profile_name) noexcept
     {
         for (size_t index = 0; index < profiles.size(); ++index)
@@ -180,11 +181,13 @@ namespace
 
         SDL_RenderPresent(&renderer);
     }
+#endif
 }
 
 ft_string run_profile_management_flow(SDL_Window *window, SDL_Renderer *renderer, TTF_Font *title_font, TTF_Font *menu_font,
     const ft_string &current_profile, bool &out_quit_requested)
 {
+#if GALACTIC_HAVE_SDL2
     out_quit_requested = false;
     if (window == ft_nullptr || renderer == ft_nullptr)
         return ft_string();
@@ -396,5 +399,14 @@ ft_string run_profile_management_flow(SDL_Window *window, SDL_Renderer *renderer
     }
 
     return ft_string();
+#else
+    (void)window;
+    (void)renderer;
+    (void)title_font;
+    (void)menu_font;
+    (void)current_profile;
+    out_quit_requested = true;
+    return ft_string();
+#endif
 }
 

--- a/profile_preferences.cpp
+++ b/profile_preferences.cpp
@@ -5,6 +5,8 @@
 
 #include "libft/CPP_class/class_nullptr.hpp"
 
+#if GALACTIC_HAVE_SDL2
+
 bool save_profile_preferences(SDL_Window *window, const ft_string &profile_name) noexcept
 {
     if (window == ft_nullptr)
@@ -39,4 +41,21 @@ void apply_profile_preferences(SDL_Window *window, const ft_string &profile_name
     if (window_width > 0 && window_height > 0)
         SDL_SetWindowSize(window, window_width, window_height);
 }
+
+#else
+
+bool save_profile_preferences(SDL_Window *window, const ft_string &profile_name) noexcept
+{
+    (void)window;
+    (void)profile_name;
+    return false;
+}
+
+void apply_profile_preferences(SDL_Window *window, const ft_string &profile_name) noexcept
+{
+    (void)window;
+    (void)profile_name;
+}
+
+#endif
 

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -2,7 +2,7 @@
 #include "../libft/System_utils/test_runner.hpp"
 #include "../libft/Networking/socket_class.hpp"
 #include "../libft/PThread/thread.hpp"
-#include "../libft/Concurrency/this_thread.hpp"
+#include "../libft/PThread/pthread.hpp"
 #include "backend_client.hpp"
 #include "buildings.hpp"
 #include "game.hpp"


### PR DESCRIPTION
## Summary
- detect SDL availability at build time and fall back to dummy SDL types when the headers are missing
- guard font/menu/profile flows so they safely stub out behavior when SDL is unavailable
- adjust the backend test to include the pthread header and refresh the test failure log

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68de7d30de508331b8a9f6c6c9cb8b1e