### PR TITLE
Fix SDL linking for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ $(TARGET): $(LIBFT) $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(SDL_LIBS) $(LDFLAGS)
 
 test: $(LIBFT) $(TEST_OBJS)
-	$(CC) $(CFLAGS) $(TEST_OBJS) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(TEST_OBJS) -o $@ $(SDL_LIBS) $(LDFLAGS)
 
 $(LIBFT):
 	$(MAKE) -C $(LIBFT_DIR) $(notdir $(LIBFT)) COMPILE_FLAGS="$(LIBFT_COMPILE_FLAGS)"


### PR DESCRIPTION
## Summary
- ensure the test executable links against the SDL2 and SDL2_ttf libraries just like the main build

## Testing
- make test *(fails: libft target Full_Libft.a missing rule)*

------
https://chatgpt.com/codex/tasks/task_e_68de818fc3b48331accf2671d5df9e04