### PR TITLE
Fix missing open_dir include in game bootstrap

### DIFF
--- a/game_bootstrap.cpp
+++ b/game_bootstrap.cpp
@@ -4,6 +4,7 @@
 #include "libft/CPP_class/class_nullptr.hpp"
 #include "libft/CPP_class/class_ofstream.hpp"
 #include "libft/File/file_utils.hpp"
+#include "libft/File/open_dir.hpp"
 #include "libft/JSon/document.hpp"
 #include "libft/JSon/json.hpp"
 #include "libft/Libft/limits.hpp"


### PR DESCRIPTION
## Summary
- include the libft open_dir header in game_bootstrap.cpp so directory helper declarations are available

## Testing
- make game_bootstrap.o

------
https://chatgpt.com/codex/tasks/task_e_68de88b731c48331ad4f3f6ed71dc138