### PR TITLE
Add dynamic menu scrolling support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -123,6 +123,7 @@ int main()
 
     ft_ui_menu menu;
     menu.set_items(build_main_menu_items());
+    menu.set_viewport_bounds(build_main_menu_viewport());
 
     bool running = true;
 

--- a/main_menu.cpp
+++ b/main_menu.cpp
@@ -1,5 +1,21 @@
 #include "main_menu_system.hpp"
 
+#include "app_constants.hpp"
+
+ft_rect build_main_menu_viewport()
+{
+    const ft_rect base_rect(460, 220, 360, 56);
+
+    ft_rect viewport = base_rect;
+    const int window_height = static_cast<int>(app_constants::kWindowHeight);
+    const int reserved_bottom = 180;
+    viewport.height = window_height - base_rect.top - reserved_bottom;
+    if (viewport.height < base_rect.height)
+        viewport.height = base_rect.height;
+
+    return viewport;
+}
+
 ft_vector<ft_menu_item> build_main_menu_items()
 {
     const ft_rect base_rect(460, 220, 360, 56);
@@ -71,6 +87,27 @@ void render_main_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *
     const int hovered_index = menu.get_hovered_index();
     const int selected_index = menu.get_selected_index();
 
+    const ft_rect &viewport = menu.get_viewport_bounds();
+    const bool clip_enabled = viewport.width > 0 && viewport.height > 0;
+    SDL_Rect clip_rect;
+    clip_rect.x = 0;
+    clip_rect.y = 0;
+    clip_rect.w = 0;
+    clip_rect.h = 0;
+    int clip_bottom = 0;
+
+    if (clip_enabled)
+    {
+        clip_rect.x = viewport.left;
+        clip_rect.y = viewport.top;
+        clip_rect.w = viewport.width;
+        clip_rect.h = viewport.height;
+        clip_bottom = clip_rect.y + clip_rect.h;
+        SDL_RenderSetClipRect(&renderer, &clip_rect);
+    }
+
+    const int scroll_offset = menu.get_scroll_offset();
+
     for (size_t index = 0; index < items.size(); ++index)
     {
         const ft_menu_item &item = items[index];
@@ -84,9 +121,12 @@ void render_main_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *
 
         SDL_Rect button_rect;
         button_rect.x = item.bounds.left;
-        button_rect.y = item.bounds.top;
+        button_rect.y = item.bounds.top - scroll_offset;
         button_rect.w = item.bounds.width;
         button_rect.h = item.bounds.height;
+
+        if (clip_enabled && (button_rect.y + button_rect.h <= clip_rect.y || button_rect.y >= clip_bottom))
+            continue;
 
         SDL_SetRenderDrawColor(&renderer, r, g, b, 255);
         SDL_RenderFillRect(&renderer, &button_rect);
@@ -102,12 +142,15 @@ void render_main_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *
             if (text_texture != ft_nullptr)
             {
                 text_rect.x = item.bounds.left + (item.bounds.width - text_rect.w) / 2;
-                text_rect.y = item.bounds.top + (item.bounds.height - text_rect.h) / 2;
+                text_rect.y = button_rect.y + (item.bounds.height - text_rect.h) / 2;
                 SDL_RenderCopy(&renderer, text_texture, ft_nullptr, &text_rect);
                 SDL_DestroyTexture(text_texture);
             }
         }
     }
+
+    if (clip_enabled)
+        SDL_RenderSetClipRect(&renderer, ft_nullptr);
 
     SDL_RenderPresent(&renderer);
 #else

--- a/main_menu_system.hpp
+++ b/main_menu_system.hpp
@@ -49,6 +49,7 @@ SDL_Texture *create_text_texture(SDL_Renderer &renderer, TTF_Font &font, const f
 
 // Main menu rendering
 ft_vector<ft_menu_item> build_main_menu_items();
+ft_rect                 build_main_menu_viewport();
 void render_main_menu(SDL_Renderer &renderer, const ft_ui_menu &menu, TTF_Font *title_font, TTF_Font *menu_font,
     int window_width, int window_height, const ft_string &active_profile_name);
 

--- a/ui_menu.hpp
+++ b/ui_menu.hpp
@@ -35,11 +35,19 @@ private:
     int                     _hovered_index;
     int                     _selected_index;
     ft_input_device_tracker _device_tracker;
+    ft_rect                 _viewport_bounds;
+    ft_rect                 _content_bounds;
+    int                     _scroll_offset;
+    int                     _max_scroll_offset;
 
     int  find_first_enabled_index() const;
     int  find_item_at(int x, int y) const;
     void move_selection(int direction);
     void synchronize_hover_with_selection();
+    void recalculate_content_bounds();
+    void update_scroll_limits();
+    void clamp_scroll_offset();
+    void scroll_to_index(int index);
 
 public:
     ft_ui_menu();
@@ -53,6 +61,10 @@ public:
     const ft_menu_item           *get_selected_item() const;
     e_ft_input_device             get_active_device() const noexcept;
     void                          set_selected_index(int index);
+    const ft_rect                &get_viewport_bounds() const noexcept;
+    int                           get_scroll_offset() const noexcept;
+    bool                          is_scrolling_enabled() const noexcept;
+    void                          set_viewport_bounds(const ft_rect &viewport);
 
     void handle_mouse_input(const ft_mouse_state &mouse);
     void handle_keyboard_input(const ft_keyboard_state &keyboard);


### PR DESCRIPTION
## Summary
- add viewport tracking and scroll management to `ft_ui_menu`
- update main and profile menus to configure scrollable areas and clip rendering to the viewport
- expose a helper for the main menu viewport and use it when building the UI

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de97ca7c5c83318ae94cab55efe217