### PR TITLE
Normalize backend scheme detection

### DIFF
--- a/backend_client.cpp
+++ b/backend_client.cpp
@@ -90,9 +90,11 @@ BackendClient::BackendClient(const ft_string &host, const ft_string &path)
     {
         ft_string scheme_value;
         assign_substring(scheme_value, input, scheme_separator);
-        if (scheme_value.size() == 5 && ft_strncmp(scheme_value.c_str(), "https", 5) == 0)
+        ft_string normalized_scheme(scheme_value);
+        ft_to_lower(normalized_scheme.print());
+        if (normalized_scheme.size() == 5 && ft_strncmp(normalized_scheme.c_str(), "https", 5) == 0)
             this->_use_ssl = true;
-        else if (scheme_value.size() == 4 && ft_strncmp(scheme_value.c_str(), "http", 4) == 0)
+        else if (normalized_scheme.size() == 4 && ft_strncmp(normalized_scheme.c_str(), "http", 4) == 0)
             this->_use_ssl = false;
         authority_start = scheme_separator + 3;
     }

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -220,6 +220,17 @@ int verify_backend_host_parsing()
     FT_ASSERT(scheme_without_port.get_port_for_testing().empty());
     FT_ASSERT(scheme_without_port.get_use_ssl_for_testing());
 
+    BackendClient uppercase_scheme(ft_string("HTTPS://example.com"), ft_string("/"));
+    FT_ASSERT_EQ(expected_scheme_host, uppercase_scheme.get_host_for_testing());
+    FT_ASSERT(uppercase_scheme.get_port_for_testing().empty());
+    FT_ASSERT(uppercase_scheme.get_use_ssl_for_testing());
+
+    BackendClient mixed_scheme(ft_string("Http://example.com:8080"), ft_string("/"));
+    FT_ASSERT_EQ(expected_scheme_host, mixed_scheme.get_host_for_testing());
+    ft_string expected_mixed_port("8080");
+    FT_ASSERT_EQ(expected_mixed_port, mixed_scheme.get_port_for_testing());
+    FT_ASSERT(!mixed_scheme.get_use_ssl_for_testing());
+
     BackendClient service_named_port(ft_string("localhost:http"), ft_string("/"));
     ft_string expected_service_host("localhost:http");
     FT_ASSERT_EQ(expected_service_host, service_named_port.get_host_for_testing());


### PR DESCRIPTION
## Summary
- normalize the parsed scheme in `BackendClient` before deciding whether to enable SSL so https/HTTP variants are handled case-insensitively
- extend backend host parsing tests to verify uppercase and mixed-case schemes use the correct SSL setting

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68debab6df5c833198838a767d812f3c