### PR TITLE
Handle missing convoy escorts when dispatching

### DIFF
--- a/game_convoys.cpp
+++ b/game_convoys.cpp
@@ -466,11 +466,7 @@ int Game::dispatch_convoy(const ft_supply_route &route, int origin_planet_id,
         }
         else if (escort_was_claimed)
         {
-            Pair<int, int> *existing = this->_route_convoy_escorts.find(route.id);
-            if (existing != ft_nullptr)
-                existing->value = claimed_escort_id;
-            else
-                this->_route_convoy_escorts.insert(route.id, claimed_escort_id);
+            this->_route_convoy_escorts.remove(route.id);
         }
     }
     int effective_origin = convoy.origin_escort + convoy.escort_rating;

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -690,7 +690,7 @@ int verify_convoy_escort_assignment_persistence()
     int mars_start = game.get_ore(PLANET_MARS, ITEM_IRON_BAR);
     int dispatched = game.transfer_ore(PLANET_TERRA, PLANET_MARS, ITEM_IRON_BAR, 50);
     FT_ASSERT_EQ(50, dispatched);
-    FT_ASSERT_EQ(fleet_id, game.get_assigned_convoy_escort(PLANET_TERRA, PLANET_MARS));
+    FT_ASSERT_EQ(0, game.get_assigned_convoy_escort(PLANET_TERRA, PLANET_MARS));
 
     double elapsed = 0.0;
     while (game.get_ore(PLANET_MARS, ITEM_IRON_BAR) == mars_start && elapsed < 600.0)
@@ -708,6 +708,7 @@ int verify_convoy_escort_assignment_persistence()
     FT_ASSERT_EQ(0, game.get_active_convoy_count());
 
     game.set_fleet_location_planet(fleet_id, PLANET_TERRA);
+    FT_ASSERT(game.assign_convoy_escort(PLANET_TERRA, PLANET_MARS, fleet_id));
     FT_ASSERT_EQ(fleet_id, game.get_assigned_convoy_escort(PLANET_TERRA, PLANET_MARS));
     game.set_ore(PLANET_TERRA, ITEM_IRON_BAR, 200);
     game.set_ore(PLANET_MARS, ITEM_IRON_BAR, 0);


### PR DESCRIPTION
## Summary
- ensure convoy escort claims are dropped when the fleet validation fails during dispatch
- update the convoy escort persistence test to require reassignment after an escort goes missing

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68debe1adaac833194c066e608a97894