### PR TITLE
Fix convoy threat decay to operate on live routes

### DIFF
--- a/game.hpp
+++ b/game.hpp
@@ -61,6 +61,7 @@ private:
     };
 
     friend int verify_supply_route_key_collisions();
+    friend int verify_supply_route_threat_decay();
     friend int verify_lore_log_retention();
 
     ft_game_state                                 _state;

--- a/game_convoys.cpp
+++ b/game_convoys.cpp
@@ -162,7 +162,11 @@ void Game::decay_all_route_threat(double seconds)
     ft_vector<Pair<RouteKey, ft_supply_route> > entries;
     ft_map_snapshot(this->_supply_routes, entries);
     for (size_t i = 0; i < entries.size(); ++i)
-        this->decay_route_threat(entries[i].value, seconds);
+    {
+        Pair<RouteKey, ft_supply_route> *entry = this->_supply_routes.find(entries[i].key);
+        if (entry != ft_nullptr)
+            this->decay_route_threat(entry->value, seconds);
+    }
 }
 
 void Game::update_route_escalation(ft_supply_route &route, double seconds)

--- a/tests/game_test_backend.cpp
+++ b/tests/game_test_backend.cpp
@@ -508,6 +508,25 @@ int verify_supply_route_key_collisions()
     return 1;
 }
 
+int verify_supply_route_threat_decay()
+{
+    Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
+
+    Game::ft_supply_route *route = game.ensure_supply_route(71000, 72000);
+    FT_ASSERT(route != ft_nullptr);
+
+    route->threat_level = 4.0;
+    route->quiet_timer = 45.0;
+
+    game.decay_all_route_threat(10.0);
+
+    FT_ASSERT(route->threat_level < 4.0);
+    FT_ASSERT(route->threat_level > 0.0);
+    FT_ASSERT(route->quiet_timer > 45.0);
+
+    return 1;
+}
+
 int verify_trade_relay_convoy_modifiers()
 {
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -47,6 +47,9 @@ int main()
     if (!verify_supply_route_key_collisions())
         return 0;
 
+    if (!verify_supply_route_threat_decay())
+        return 0;
+
     if (!verify_trade_relay_convoy_modifiers())
         return 0;
 

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -16,6 +16,7 @@ int verify_supply_contract_pending_stock_buffer();
 int verify_convoy_quest_objectives();
 int verify_multiple_convoy_raids();
 int verify_supply_route_escalation();
+int verify_supply_route_threat_decay();
 int verify_escort_veterancy_progression();
 int compare_energy_pressure_scenarios();
 int verify_crafting_resume_requires_full_cycle();


### PR DESCRIPTION
## Summary
- ensure convoy threat decay looks up each route in the live map before updating
- expose the new convoy regression test via a friend declaration and register it with the test harness
- add a backend test that exercises convoy threat decay when the quiet timer exceeds the decay delay

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68dec216e0448331aa808345d688b397