### PR TITLE
Fix building tick state persistence

### DIFF
--- a/buildings.cpp
+++ b/buildings.cpp
@@ -687,5 +687,10 @@ void BuildingManager::tick(Game &game, double seconds)
     ft_vector<Pair<int, ft_planet_build_state> > entries;
     ft_map_snapshot(this->_planets, entries);
     for (size_t i = 0; i < entries.size(); ++i)
-        this->tick_planet(game, entries[i].value, seconds);
+    {
+        Pair<int, ft_planet_build_state> *entry = this->_planets.find(entries[i].key);
+        if (entry == ft_nullptr)
+            continue;
+        this->tick_planet(game, entry->value, seconds);
+    }
 }

--- a/tests/game_test_energy.cpp
+++ b/tests/game_test_energy.cpp
@@ -124,6 +124,35 @@ int compare_energy_pressure_scenarios()
     return 1;
 }
 
+int verify_building_tick_state_persistence()
+{
+    Game tick_game(ft_string("127.0.0.1:8080"), ft_string("/"));
+    tick_game.set_ore(PLANET_TERRA, ORE_IRON, 120);
+    tick_game.set_ore(PLANET_TERRA, ORE_COPPER, 120);
+    tick_game.set_ore(PLANET_TERRA, ORE_COAL, 120);
+
+    FT_ASSERT(tick_game.place_building(PLANET_TERRA, BUILDING_POWER_GENERATOR, 0, 1) != 0);
+    FT_ASSERT(tick_game.place_building(PLANET_TERRA, BUILDING_SMELTER, 2, 0) != 0);
+
+    tick_game.tick(0.0);
+    double baseline_energy = tick_game.get_planet_energy_consumption(PLANET_TERRA);
+    int baseline_logistic = tick_game.get_planet_logistic_usage(PLANET_TERRA);
+    int baseline_bars = tick_game.get_ore(PLANET_TERRA, ITEM_IRON_BAR);
+
+    tick_game.tick(1.0);
+    double active_energy = tick_game.get_planet_energy_consumption(PLANET_TERRA);
+    int active_logistic = tick_game.get_planet_logistic_usage(PLANET_TERRA);
+    FT_ASSERT(active_energy > baseline_energy + 0.5);
+    FT_ASSERT(active_logistic > baseline_logistic);
+
+    for (int step = 0; step < 5; ++step)
+        tick_game.tick(1.0);
+
+    int produced_bars = tick_game.get_ore(PLANET_TERRA, ITEM_IRON_BAR);
+    FT_ASSERT(produced_bars > baseline_bars);
+    return 1;
+}
+
 int verify_crafting_resume_requires_full_cycle()
 {
     Game production_game(ft_string("127.0.0.1:8080"), ft_string("/"));

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -91,6 +91,9 @@ int main()
         return 0;
 
 
+    if (!verify_building_tick_state_persistence())
+        return 0;
+
     if (!compare_energy_pressure_scenarios())
         return 0;
     if (!verify_crafting_resume_requires_full_cycle())

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -18,6 +18,7 @@ int verify_multiple_convoy_raids();
 int verify_supply_route_escalation();
 int verify_supply_route_threat_decay();
 int verify_escort_veterancy_progression();
+int verify_building_tick_state_persistence();
 int compare_energy_pressure_scenarios();
 int verify_crafting_resume_requires_full_cycle();
 int compare_storyline_assaults();


### PR DESCRIPTION
## Summary
- ensure building ticks operate on live planet state by re-fetching entries before updating
- add a regression test that confirms energy consumption, logistics, and production advance after ticking
- register the new scenario in the shared test runner declarations and dispatch

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68dec746c9c88331834b72dbc1642f58