### PR TITLE
Prevent convoy escort double counting

### DIFF
--- a/game.hpp
+++ b/game.hpp
@@ -63,6 +63,7 @@ private:
     friend int verify_supply_route_key_collisions();
     friend int verify_supply_route_threat_decay();
     friend int verify_lore_log_retention();
+    friend int verify_convoy_escort_rating_excludes_active_escort();
 
     ft_game_state                                 _state;
     ft_map<int, ft_sharedptr<ft_planet> >         _planets;

--- a/tests/game_test_main.cpp
+++ b/tests/game_test_main.cpp
@@ -68,6 +68,9 @@ int main()
     if (!verify_convoy_escort_assignment_persistence())
         return 0;
 
+    if (!verify_convoy_escort_rating_excludes_active_escort())
+        return 0;
+
     Game game(ft_string("127.0.0.1:8080"), ft_string("/"));
     if (!validate_initial_campaign_flow(game))
         return 0;

--- a/tests/game_test_scenarios.hpp
+++ b/tests/game_test_scenarios.hpp
@@ -45,6 +45,7 @@ int verify_supply_route_key_collisions();
 int verify_trade_relay_convoy_modifiers();
 int verify_convoy_escort_travel_speed();
 int verify_convoy_escort_assignment_persistence();
+int verify_convoy_escort_rating_excludes_active_escort();
 int verify_achievement_catalog();
 int verify_achievement_progression();
 int verify_quest_achievement_failures();


### PR DESCRIPTION
## Summary
- avoid counting fleets already escorting a convoy when computing planet escort ratings and update their travel/location state when convoys depart or finish
- grant test access and add coverage ensuring convoy escort rating calculations exclude active escort fleets

## Testing
- make test
- ./test

------
https://chatgpt.com/codex/tasks/task_e_68decfc8b38c8331984e0f6d68129a5d